### PR TITLE
feat: expose streaming C API for native macOS/iOS integration

### DIFF
--- a/crates/qwen-asr/Cargo.toml
+++ b/crates/qwen-asr/Cargo.toml
@@ -11,6 +11,7 @@ documentation = "https://docs.rs/qwen-asr"
 readme = "README.md"
 
 [lib]
+crate-type = ["cdylib", "staticlib", "rlib"]
 name = "qwen_asr"
 
 [dependencies]
@@ -25,3 +26,4 @@ blas = []
 vdsp = []
 ios = []
 android = []
+macos-ffi = []

--- a/crates/qwen-asr/src/lib.rs
+++ b/crates/qwen-asr/src/lib.rs
@@ -65,7 +65,7 @@ pub mod decoder;
 pub mod context;
 pub mod transcribe;
 pub mod align;
-#[cfg(any(feature = "ios", feature = "android"))]
+#[cfg(any(feature = "ios", feature = "android", feature = "macos-ffi"))]
 pub mod c_api;
 #[cfg(feature = "android")]
 pub mod jni_api;


### PR DESCRIPTION
## Summary

- Expose the existing internal streaming engine (`StreamState` + `stream_push_audio`) via C FFI functions
- The streaming core already exists in `transcribe.rs` but was only accessible from Rust — this PR makes it available to C/Swift/Objective-C callers
- Add a `macos-ffi` feature flag so macOS native apps can build `libqwen_asr.dylib` with streaming support

## New C API Functions

| Function | Purpose |
|----------|---------|
| `qwen_asr_stream_new()` | Create streaming state |
| `qwen_asr_stream_free()` | Free streaming state |
| `qwen_asr_stream_reset()` | Reset for new utterance |
| `qwen_asr_stream_push()` | Push audio chunk, get text delta |
| `qwen_asr_stream_get_result()` | Get full accumulated result |
| `qwen_asr_stream_set_chunk_sec()` | Configure chunk size (default 2.0s) |
| `qwen_asr_stream_set_rollback()` | Configure rollback window (default 5) |
| `qwen_asr_stream_set_unfixed_chunks()` | Configure unfixed chunks (default 2) |
| `qwen_asr_stream_set_max_new_tokens()` | Configure max tokens/chunk (default 32) |

## Build

```bash
# macOS dylib + static lib with streaming API
cargo build --release --features macos-ffi
```

## Test plan

- [x] `cargo build --features macos-ffi` compiles successfully
- [ ] Integration test with Swift caller via bridging header
- [ ] Verify streaming output matches `transcribe_stream` for the same audio input

🤖 Generated with [Claude Code](https://claude.com/claude-code)