### PR TITLE
Replace libc::mmap with memmap2 for cross-platform support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -344,6 +344,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,9 +446,9 @@ dependencies = [
 
 [[package]]
 name = "qwen-asr"
-version = "0.6.0"
+version = "0.7.1"
 dependencies = [
- "libc",
+ "memmap2",
 ]
 
 [[package]]

--- a/crates/qwen-asr/Cargo.toml
+++ b/crates/qwen-asr/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "staticlib", "rlib"]
 name = "qwen_asr"
 
 [dependencies]
-libc = "0.2"
+memmap2 = "0.9"
 
 [package.metadata.docs.rs]
 no-default-features = true

--- a/crates/qwen-asr/build.rs
+++ b/crates/qwen-asr/build.rs
@@ -9,7 +9,13 @@ fn main() {
             }
             "linux" => {
                 println!("cargo:rustc-link-lib=openblas");
-            }
+            },
+            "windows" => {
+                if let Ok(dir) = std::env::var("OPENBLAS_LIB_DIR") {
+                    println!("cargo:rustc-link-search=native={dir}");
+                }
+                println!("cargo:rustc-link-lib=openblas_64");
+            },
             _ => {
                 // No BLAS available, will use fallback matmul
             }

--- a/crates/qwen-asr/build.rs
+++ b/crates/qwen-asr/build.rs
@@ -9,13 +9,13 @@ fn main() {
             }
             "linux" => {
                 println!("cargo:rustc-link-lib=openblas");
-            },
+            }
             "windows" => {
                 if let Ok(dir) = std::env::var("OPENBLAS_LIB_DIR") {
                     println!("cargo:rustc-link-search=native={dir}");
                 }
                 println!("cargo:rustc-link-lib=openblas_64");
-            },
+            }
             _ => {
                 // No BLAS available, will use fallback matmul
             }

--- a/crates/qwen-asr/src/safetensors.rs
+++ b/crates/qwen-asr/src/safetensors.rs
@@ -1,7 +1,6 @@
 //! Safetensors mmap reader with multi-shard support.
 
 use std::collections::HashMap;
-use std::os::unix::io::RawFd;
 use std::path::Path;
 
 const MAX_TENSORS: usize = 1024;
@@ -57,7 +56,7 @@ impl TensorMeta {
 }
 
 pub struct SafetensorsFile {
-    _fd: RawFd,
+    _mmap: memmap2::Mmap,
     data: *mut u8,
     file_size: usize,
     header_size: usize,
@@ -70,46 +69,13 @@ unsafe impl Sync for SafetensorsFile {}
 
 impl SafetensorsFile {
     pub fn open(path: &str) -> Option<Self> {
-        use libc::*;
-        use std::ffi::CString;
-
-        let c_path = CString::new(path).ok()?;
-        let fd = unsafe { open(c_path.as_ptr(), O_RDONLY) };
-        if fd < 0 {
-            return None;
-        }
-
-        let mut stat_buf = unsafe { std::mem::zeroed::<stat>() };
-        if unsafe { fstat(fd, &mut stat_buf) } < 0 {
-            unsafe { close(fd); }
-            return None;
-        }
-
-        let file_size = stat_buf.st_size as usize;
+        let file = std::fs::File::open(path).ok()?;
+        let mmap = unsafe { memmap2::Mmap::map(&file).ok()? };
+        let file_size = mmap.len();
         if file_size < 8 {
-            unsafe { close(fd); }
             return None;
         }
-
-        let data = unsafe {
-            mmap(
-                std::ptr::null_mut(),
-                file_size,
-                PROT_READ,
-                MAP_PRIVATE,
-                fd,
-                0,
-            )
-        };
-        // Keep fd open for mmap lifetime? Actually mmap doesn't need it.
-        // But we close it since MAP_PRIVATE doesn't need fd after mmap.
-        let raw_fd = fd;
-        unsafe { close(fd); }
-
-        if data == libc::MAP_FAILED {
-            return None;
-        }
-        let data = data as *mut u8;
+        let data = mmap.as_ptr() as *mut u8;
 
         // Read header size (first 8 bytes, little-endian u64)
         let header_size = unsafe {
@@ -119,7 +85,6 @@ impl SafetensorsFile {
         };
 
         if header_size > file_size - 8 {
-            unsafe { munmap(data as *mut _, file_size); }
             return None;
         }
 
@@ -136,7 +101,7 @@ impl SafetensorsFile {
         }
 
         Some(SafetensorsFile {
-            _fd: raw_fd,
+            _mmap: mmap,
             data,
             file_size,
             header_size,
@@ -196,11 +161,7 @@ impl SafetensorsFile {
 
 impl Drop for SafetensorsFile {
     fn drop(&mut self) {
-        if !self.data.is_null() {
-            unsafe {
-                libc::munmap(self.data as *mut _, self.file_size);
-            }
-        }
+        // memmap2::Mmap handles unmapping on drop
     }
 }
 


### PR DESCRIPTION
Removes Unix-specific dependencies (`RawFd`, `libc::mmap`, `libc::munmap`) and replaces them with the `memmap2` crate, which wraps native Windows APIs on Windows and remains a thin wrapper around `mmap` on Unix-like systems.

- Removes `std::os::unix::io::RawFd` usage
- Removes `libc` dependency
- Adds `memmap2 = "0.9"`
- `memmap2::Mmap` handles unmapping on `Drop`

This enables Windows builds without any runtime overhead on Unix.