### PR TITLE
perf: keep weights as BF16 mmap views to fit on iOS

### DIFF
--- a/crates/qwen-asr/src/decoder.rs
+++ b/crates/qwen-asr/src/decoder.rs
@@ -44,10 +44,6 @@ pub struct DecLayer {
     pub wk_weight_bf16: *const u16,
     pub wv_weight_bf16: *const u16,
     pub wo_weight_bf16: *const u16,
-    pub wq_weight_f32_prefill: Vec<f32>,
-    pub wk_weight_f32_prefill: Vec<f32>,
-    pub wv_weight_f32_prefill: Vec<f32>,
-    pub wo_weight_f32_prefill: Vec<f32>,
     pub q_norm_weight: Vec<f32>,
     pub k_norm_weight: Vec<f32>,
     pub input_norm: Vec<f32>,
@@ -55,10 +51,12 @@ pub struct DecLayer {
     pub gate_weight_bf16: *const u16,
     pub up_weight_bf16: *const u16,
     pub down_weight_bf16: *const u16,
-    pub gate_up_fused_bf16: Vec<u16>, // owned, interleaved
-    pub gate_up_fused_f32_prefill: Vec<f32>,
-    pub down_weight_f32_prefill: Vec<f32>,
-    /// INT8 quantized attention weights + per-row scales
+    /// Owned interleaved bf16 fusion of gate+up — populated only for non-aligner
+    /// configs (single-token decode path uses it). Empty for forced-aligner since
+    /// aligner only ever runs prefill, which streams gate/up separately.
+    pub gate_up_fused_bf16: Vec<u16>,
+    /// INT8 quantized attention weights + per-row scales — populated only for
+    /// non-aligner configs (used by aarch64 single-token decode). Empty for aligner.
     pub wq_int8: Vec<i8>,
     pub wq_int8_scales: Vec<f32>,
     pub wk_int8: Vec<i8>,
@@ -67,7 +65,6 @@ pub struct DecLayer {
     pub wv_int8_scales: Vec<f32>,
     pub wo_int8: Vec<i8>,
     pub wo_int8_scales: Vec<f32>,
-    /// INT8 quantized FFN weights + per-row scales
     pub gate_up_int8: Vec<i8>,
     pub gate_up_int8_scales: Vec<f32>,
     pub down_int8: Vec<i8>,
@@ -83,7 +80,7 @@ pub struct Decoder {
     pub norm: Vec<f32>,
     /// Separate lm_head for forced aligner (None = tied weights with tok_embeddings)
     pub lm_head_bf16: Option<*const u16>,
-    /// INT8 quantized lm_head weights for fast argmax
+    /// INT8 quantized lm_head weights for fast argmax — None for aligner (uses bf16 path).
     pub lm_head_int8: Option<Vec<i8>>,
     pub lm_head_int8_scales: Option<Vec<f32>>,
 }
@@ -107,17 +104,11 @@ fn load_bf16_direct(ms: &MultiSafetensors, name: &str) -> Option<*const u16> {
     result
 }
 
-fn load_bf16_as_f32_into(ms: &MultiSafetensors, name: &str, out: &mut [f32]) -> Option<()> {
-    let ptr = load_bf16_direct(ms, name)?;
-    unsafe {
-        let src = std::slice::from_raw_parts(ptr, out.len());
-        kernels::bf16_to_f32_buf(out, src);
-    }
-    Some(())
-}
-
-/// Load and preprocess a single decoder layer's weights (bf16->f32 prefill copies
-/// + INT8 quantized copies). Independent per layer, so callable in parallel.
+/// Load a single decoder layer. For non-aligner configs we still build the
+/// INT8 + interleaved-bf16 fusion that the single-token decode path needs;
+/// for aligner configs (which only ever runs prefill) we skip those — saving
+/// roughly 700 MB across the model — and let the prefill code stream BF16
+/// weights through a shared f32 scratch buffer.
 fn load_dec_layer(ms: &MultiSafetensors, cfg: &QwenConfig, i: usize) -> Option<DecLayer> {
     let lp = format!("thinker.model.layers.{}", i);
 
@@ -130,27 +121,6 @@ fn load_dec_layer(ms: &MultiSafetensors, cfg: &QwenConfig, i: usize) -> Option<D
     let hidden = cfg.dec_hidden;
     let inter = cfg.dec_intermediate;
 
-    let wq_weight_f32_prefill = {
-        let mut v = superpage_vec::<f32>(q_dim * hidden);
-        load_bf16_as_f32_into(ms, &format!("{}.self_attn.q_proj.weight", lp), &mut v)?;
-        v
-    };
-    let wk_weight_f32_prefill = {
-        let mut v = superpage_vec::<f32>(kv_dim * hidden);
-        load_bf16_as_f32_into(ms, &format!("{}.self_attn.k_proj.weight", lp), &mut v)?;
-        v
-    };
-    let wv_weight_f32_prefill = {
-        let mut v = superpage_vec::<f32>(kv_dim * hidden);
-        load_bf16_as_f32_into(ms, &format!("{}.self_attn.v_proj.weight", lp), &mut v)?;
-        v
-    };
-    let wo_weight_f32_prefill = {
-        let mut v = superpage_vec::<f32>(hidden * q_dim);
-        load_bf16_as_f32_into(ms, &format!("{}.self_attn.o_proj.weight", lp), &mut v)?;
-        v
-    };
-
     let q_norm = load_f32(ms, &format!("{}.self_attn.q_norm.weight", lp))?;
     let k_norm = load_f32(ms, &format!("{}.self_attn.k_norm.weight", lp))?;
     let input_norm = load_f32(ms, &format!("{}.input_layernorm.weight", lp))?;
@@ -160,44 +130,50 @@ fn load_dec_layer(ms: &MultiSafetensors, cfg: &QwenConfig, i: usize) -> Option<D
     let up_bf16 = load_bf16_direct(ms, &format!("{}.mlp.up_proj.weight", lp))?;
     let down_bf16 = load_bf16_direct(ms, &format!("{}.mlp.down_proj.weight", lp))?;
 
-    // Fuse gate+up: interleave rows
-    let mut gate_up_fused = vec![0u16; 2 * inter * hidden];
-    unsafe {
-        let gate_slice = std::slice::from_raw_parts(gate_bf16, inter * hidden);
-        let up_slice = std::slice::from_raw_parts(up_bf16, inter * hidden);
-        for r in 0..inter {
-            gate_up_fused[2 * r * hidden..(2 * r + 1) * hidden]
-                .copy_from_slice(&gate_slice[r * hidden..(r + 1) * hidden]);
-            gate_up_fused[(2 * r + 1) * hidden..(2 * r + 2) * hidden]
-                .copy_from_slice(&up_slice[r * hidden..(r + 1) * hidden]);
-        }
-    }
-    let mut gate_up_fused_f32_prefill = superpage_vec::<f32>(2 * inter * hidden);
-    kernels::bf16_to_f32_buf(&mut gate_up_fused_f32_prefill, &gate_up_fused);
-    let down_weight_f32_prefill = {
-        let mut v = superpage_vec::<f32>(hidden * inter);
-        load_bf16_as_f32_into(ms, &format!("{}.mlp.down_proj.weight", lp), &mut v)?;
-        v
-    };
+    let is_aligner = cfg.is_aligner();
 
-    // INT8 quantize all decoder layer weights into superpage-aligned buffers
-    let (wq_int8, wq_int8_scales) = quantize_to_superpage(wq, q_dim, hidden);
-    let (wk_int8, wk_int8_scales) = quantize_to_superpage(wk, kv_dim, hidden);
-    let (wv_int8, wv_int8_scales) = quantize_to_superpage(wv, kv_dim, hidden);
-    let (wo_int8, wo_int8_scales) = quantize_to_superpage(wo, hidden, q_dim);
-    let (gate_up_int8, gate_up_int8_scales) =
-        quantize_to_superpage(gate_up_fused.as_ptr(), 2 * inter, hidden);
-    let (down_int8, down_int8_scales) = quantize_to_superpage(down_bf16, hidden, inter);
+    // Non-aligner: build interleaved bf16 fusion + INT8 quant for fast decode.
+    // Aligner: leave them empty (saves ~700 MB across the model).
+    let (gate_up_fused_bf16, wq_int8, wq_int8_scales, wk_int8, wk_int8_scales,
+         wv_int8, wv_int8_scales, wo_int8, wo_int8_scales,
+         gate_up_int8, gate_up_int8_scales, down_int8, down_int8_scales) = if is_aligner {
+        (Vec::new(),
+         Vec::new(), Vec::new(), Vec::new(), Vec::new(),
+         Vec::new(), Vec::new(), Vec::new(), Vec::new(),
+         Vec::new(), Vec::new(), Vec::new(), Vec::new())
+    } else {
+        // Fuse gate+up: interleave rows
+        let mut gate_up_fused = vec![0u16; 2 * inter * hidden];
+        unsafe {
+            let gate_slice = std::slice::from_raw_parts(gate_bf16, inter * hidden);
+            let up_slice = std::slice::from_raw_parts(up_bf16, inter * hidden);
+            for r in 0..inter {
+                gate_up_fused[2 * r * hidden..(2 * r + 1) * hidden]
+                    .copy_from_slice(&gate_slice[r * hidden..(r + 1) * hidden]);
+                gate_up_fused[(2 * r + 1) * hidden..(2 * r + 2) * hidden]
+                    .copy_from_slice(&up_slice[r * hidden..(r + 1) * hidden]);
+            }
+        }
+
+        let (wq_int8, wq_int8_scales) = quantize_to_superpage(wq, q_dim, hidden);
+        let (wk_int8, wk_int8_scales) = quantize_to_superpage(wk, kv_dim, hidden);
+        let (wv_int8, wv_int8_scales) = quantize_to_superpage(wv, kv_dim, hidden);
+        let (wo_int8, wo_int8_scales) = quantize_to_superpage(wo, hidden, q_dim);
+        let (gate_up_int8, gate_up_int8_scales) =
+            quantize_to_superpage(gate_up_fused.as_ptr(), 2 * inter, hidden);
+        let (down_int8, down_int8_scales) = quantize_to_superpage(down_bf16, hidden, inter);
+
+        (gate_up_fused,
+         wq_int8, wq_int8_scales, wk_int8, wk_int8_scales,
+         wv_int8, wv_int8_scales, wo_int8, wo_int8_scales,
+         gate_up_int8, gate_up_int8_scales, down_int8, down_int8_scales)
+    };
 
     Some(DecLayer {
         wq_weight_bf16: wq,
         wk_weight_bf16: wk,
         wv_weight_bf16: wv,
         wo_weight_bf16: wo,
-        wq_weight_f32_prefill,
-        wk_weight_f32_prefill,
-        wv_weight_f32_prefill,
-        wo_weight_f32_prefill,
         q_norm_weight: q_norm,
         k_norm_weight: k_norm,
         input_norm,
@@ -205,9 +181,7 @@ fn load_dec_layer(ms: &MultiSafetensors, cfg: &QwenConfig, i: usize) -> Option<D
         gate_weight_bf16: gate_bf16,
         up_weight_bf16: up_bf16,
         down_weight_bf16: down_bf16,
-        gate_up_fused_bf16: gate_up_fused,
-        gate_up_fused_f32_prefill,
-        down_weight_f32_prefill,
+        gate_up_fused_bf16,
         wq_int8,
         wq_int8_scales,
         wk_int8,
@@ -268,19 +242,25 @@ impl Decoder {
             ms.get_bf16_direct("thinker.lm_head.weight")
         };
 
-        // Quantize lm_head to INT8 for fast argmax
-        let lm_weight = lm_head_bf16.unwrap_or(tok_embeddings_bf16);
-        let lm_out_dim = cfg.lm_head_dim();
-        let lm_in_dim = cfg.dec_hidden;
-        let (lm_int8, lm_scales) = quantize_to_superpage(lm_weight, lm_out_dim, lm_in_dim);
+        // Quantize lm_head to INT8 for fast argmax — skipped for aligner since
+        // aligner never does single-token decode (all logits read out of prefill).
+        let (lm_int8_opt, lm_scales_opt) = if cfg.is_aligner() {
+            (None, None)
+        } else {
+            let lm_weight = lm_head_bf16.unwrap_or(tok_embeddings_bf16);
+            let lm_out_dim = cfg.lm_head_dim();
+            let lm_in_dim = cfg.dec_hidden;
+            let (lm_int8, lm_scales) = quantize_to_superpage(lm_weight, lm_out_dim, lm_in_dim);
+            (Some(lm_int8), Some(lm_scales))
+        };
 
         Some(Decoder {
             tok_embeddings_bf16,
             layers,
             norm,
             lm_head_bf16,
-            lm_head_int8: Some(lm_int8),
-            lm_head_int8_scales: Some(lm_scales),
+            lm_head_int8: lm_int8_opt,
+            lm_head_int8_scales: lm_scales_opt,
         })
     }
 }
@@ -497,11 +477,14 @@ pub struct DecoderBuffers {
     pub pref_attn_out: Vec<f32>,
     pub pref_proj_out: Vec<f32>,
     pub pref_ffn_out: Vec<f32>,
-    pub pref_gate_up: Vec<f32>,
+    /// Separate gate and up projection outputs — replaces the old single fused
+    /// pref_gate_up buffer (which paired with the 700 MB owned bf16 fusion).
     pub pref_gate: Vec<f32>,
+    pub pref_up: Vec<f32>,
     pub pref_seq_cap: usize,
 
-    // Reusable scratch for BF16→F32 conversion in prefill path
+    /// Reusable scratch for BF16→F32 conversion in prefill path. Sized to the
+    /// largest weight matrix the decoder ever streams in (down_proj or gate/up).
     pub bf16_scratch: Vec<f32>,
 }
 
@@ -512,8 +495,10 @@ impl DecoderBuffers {
         let kv_dim = cfg.dec_kv_heads * cfg.dec_head_dim;
         let intermediate = cfg.dec_intermediate;
 
-        // Largest weight matrix is gate_up_fused: 2 * intermediate * hidden
-        let max_weight = (2 * intermediate * dim).max(q_dim * dim).max(kv_dim * dim);
+        // Largest weight matrix the prefill streams: down_proj (hidden*inter)
+        // or gate/up (inter*hidden). lm_head can be bigger for non-aligner —
+        // grown lazily by ensure_scratch.
+        let max_weight = (intermediate * dim).max(q_dim * dim).max(kv_dim * dim);
 
         DecoderBuffers {
             x: vec![0.0f32; dim],
@@ -533,8 +518,8 @@ impl DecoderBuffers {
             pref_attn_out: Vec::new(),
             pref_proj_out: Vec::new(),
             pref_ffn_out: Vec::new(),
-            pref_gate_up: Vec::new(),
             pref_gate: Vec::new(),
+            pref_up: Vec::new(),
             pref_seq_cap: 0,
             bf16_scratch: vec![0.0f32; max_weight],
         }
@@ -567,9 +552,15 @@ impl DecoderBuffers {
         self.pref_attn_out.resize(new_cap * q_dim, 0.0);
         self.pref_proj_out.resize(new_cap * dim, 0.0);
         self.pref_ffn_out.resize(new_cap * dim, 0.0);
-        self.pref_gate_up.resize(new_cap * 2 * intermediate, 0.0);
         self.pref_gate.resize(new_cap * intermediate, 0.0);
+        self.pref_up.resize(new_cap * intermediate, 0.0);
         self.pref_seq_cap = new_cap;
+    }
+
+    pub fn ensure_scratch(&mut self, n: usize) {
+        if self.bf16_scratch.len() < n {
+            self.bf16_scratch.resize(n, 0.0);
+        }
     }
 }
 
@@ -611,6 +602,13 @@ pub fn decoder_prefill(
 
     let scale = 1.0 / (head_dim as f32).sqrt();
 
+    // Make sure the BF16→F32 scratch is sized to the largest weight matrix the
+    // prefill will stream through: down_proj (hidden × intermediate). Some
+    // attention matrices are smaller; gate/up are (intermediate × hidden) which
+    // is the same size.
+    let max_weight = (intermediate * dim).max(q_dim * dim).max(kv_dim * dim);
+    bufs.ensure_scratch(max_weight);
+
     for (layer_idx, layer) in decoder.layers.iter().enumerate() {
         let x_norm = &mut bufs.pref_x_norm[..seq_len * dim];
         kernels::rms_norm(
@@ -626,23 +624,20 @@ pub fn decoder_prefill(
         let k = &mut bufs.pref_k[..seq_len * kv_dim];
         let v = &mut bufs.pref_v[..seq_len * kv_dim];
 
-        kernels::linear_nobias(q, x_norm, &layer.wq_weight_f32_prefill, seq_len, dim, q_dim);
-        kernels::linear_nobias(
-            k,
-            x_norm,
-            &layer.wk_weight_f32_prefill,
-            seq_len,
-            dim,
-            kv_dim,
-        );
-        kernels::linear_nobias(
-            v,
-            x_norm,
-            &layer.wv_weight_f32_prefill,
-            seq_len,
-            dim,
-            kv_dim,
-        );
+        unsafe {
+            kernels::linear_nobias_bf16_scratch(
+                q, x_norm, layer.wq_weight_bf16, seq_len, dim, q_dim,
+                &mut bufs.bf16_scratch,
+            );
+            kernels::linear_nobias_bf16_scratch(
+                k, x_norm, layer.wk_weight_bf16, seq_len, dim, kv_dim,
+                &mut bufs.bf16_scratch,
+            );
+            kernels::linear_nobias_bf16_scratch(
+                v, x_norm, layer.wv_weight_bf16, seq_len, dim, kv_dim,
+                &mut bufs.bf16_scratch,
+            );
+        }
 
         kernels::rms_norm_per_head(q, &layer.q_norm_weight, seq_len, n_heads, head_dim, eps);
         kernels::rms_norm_per_head(k, &layer.k_norm_weight, seq_len, n_kv_heads, head_dim, eps);
@@ -686,14 +681,12 @@ pub fn decoder_prefill(
         );
 
         let proj_out = &mut bufs.pref_proj_out[..seq_len * dim];
-        kernels::linear_nobias(
-            proj_out,
-            attn_out,
-            &layer.wo_weight_f32_prefill,
-            seq_len,
-            q_dim,
-            dim,
-        );
+        unsafe {
+            kernels::linear_nobias_bf16_scratch(
+                proj_out, attn_out, layer.wo_weight_bf16, seq_len, q_dim, dim,
+                &mut bufs.bf16_scratch,
+            );
+        }
         kernels::add_inplace(&mut bufs.pref_x[..seq_len * dim], proj_out, seq_len * dim);
 
         // Post-attention RMSNorm + SwiGLU MLP
@@ -707,28 +700,34 @@ pub fn decoder_prefill(
             eps,
         );
 
-        let gate_up = &mut bufs.pref_gate_up[..seq_len * 2 * intermediate];
-        kernels::linear_nobias(
-            gate_up,
-            x_norm2,
-            &layer.gate_up_fused_f32_prefill,
-            seq_len,
-            dim,
-            2 * intermediate,
-        );
-
+        // Two separate GEMMs into pref_gate/pref_up, then fused swiglu — replaces
+        // the prior interleaved-fusion path that needed an extra ~700 MB owned
+        // bf16 matrix across the decoder.
         let gate = &mut bufs.pref_gate[..seq_len * intermediate];
-        kernels::swiglu_multiply(gate, gate_up, seq_len, intermediate);
+        unsafe {
+            kernels::linear_nobias_bf16_scratch(
+                gate, x_norm2, layer.gate_weight_bf16, seq_len, dim, intermediate,
+                &mut bufs.bf16_scratch,
+            );
+        }
+        let up = &mut bufs.pref_up[..seq_len * intermediate];
+        unsafe {
+            kernels::linear_nobias_bf16_scratch(
+                up, x_norm2, layer.up_weight_bf16, seq_len, dim, intermediate,
+                &mut bufs.bf16_scratch,
+            );
+        }
+
+        // gate <- silu(gate) * up
+        kernels::swiglu_separate_inplace(gate, up, seq_len, intermediate);
 
         let ffn_out = &mut bufs.pref_ffn_out[..seq_len * dim];
-        kernels::linear_nobias(
-            ffn_out,
-            gate,
-            &layer.down_weight_f32_prefill,
-            seq_len,
-            intermediate,
-            dim,
-        );
+        unsafe {
+            kernels::linear_nobias_bf16_scratch(
+                ffn_out, gate, layer.down_weight_bf16, seq_len, intermediate, dim,
+                &mut bufs.bf16_scratch,
+            );
+        }
         kernels::add_inplace(&mut bufs.pref_x[..seq_len * dim], ffn_out, seq_len * dim);
     }
 
@@ -978,6 +977,10 @@ pub fn decoder_prefill_logits(
     kernels::rms_norm(&mut x_norm, x, &decoder.norm, seq_len, dim, eps);
 
     let lm_weight = decoder.lm_head_bf16.unwrap_or(decoder.tok_embeddings_bf16);
+
+    // lm_head can be larger than the per-layer matrices (out_dim × dim where
+    // out_dim is vocab_size or classify_num), so grow the scratch buffer first.
+    bufs.ensure_scratch(out_dim * dim);
 
     // Project each position through lm_head: [seq_len × dim] × [out_dim × dim]^T → [seq_len × out_dim]
     let mut logits = vec![0.0f32; seq_len * out_dim];

--- a/crates/qwen-asr/src/encoder.rs
+++ b/crates/qwen-asr/src/encoder.rs
@@ -4,24 +4,31 @@ use crate::config::*;
 use crate::kernels;
 use crate::safetensors::MultiSafetensors;
 
+/// Encoder transformer layer. Large weight matrices are kept as BF16 pointers
+/// into the mmap'd safetensors file — converted to f32 on the fly through a
+/// shared scratch buffer at each GEMM. Small per-output biases / norm params
+/// stay as f32 since they're tiny.
 pub struct EncLayer {
-    pub wq_weight: Vec<f32>,
+    pub wq_weight_bf16: *const u16,
     pub wq_bias: Vec<f32>,
-    pub wk_weight: Vec<f32>,
+    pub wk_weight_bf16: *const u16,
     pub wk_bias: Vec<f32>,
-    pub wv_weight: Vec<f32>,
+    pub wv_weight_bf16: *const u16,
     pub wv_bias: Vec<f32>,
-    pub wo_weight: Vec<f32>,
+    pub wo_weight_bf16: *const u16,
     pub wo_bias: Vec<f32>,
     pub attn_norm_weight: Vec<f32>,
     pub attn_norm_bias: Vec<f32>,
-    pub fc1_weight: Vec<f32>,
+    pub fc1_weight_bf16: *const u16,
     pub fc1_bias: Vec<f32>,
-    pub fc2_weight: Vec<f32>,
+    pub fc2_weight_bf16: *const u16,
     pub fc2_bias: Vec<f32>,
     pub ffn_norm_weight: Vec<f32>,
     pub ffn_norm_bias: Vec<f32>,
 }
+
+unsafe impl Send for EncLayer {}
+unsafe impl Sync for EncLayer {}
 
 pub struct EncoderBuffers {
     pub x: Vec<f32>,
@@ -41,6 +48,9 @@ pub struct EncoderBuffers {
     pub pe: Vec<f32>,
     pub conv_cols: Vec<f32>,
     pub window_starts: Vec<i32>,
+    /// Shared f32 scratch buffer for streaming BF16 weights into the GEMM kernel.
+    /// Sized to the largest weight matrix the encoder ever sees.
+    pub bf16_scratch: Vec<f32>,
     pub cap_tokens: usize,
 }
 
@@ -70,6 +80,7 @@ impl EncoderBuffers {
             pe: Vec::new(),
             conv_cols: Vec::new(),
             window_starts: Vec::new(),
+            bf16_scratch: Vec::new(),
             cap_tokens: 0,
         }
     }
@@ -114,6 +125,12 @@ impl EncoderBuffers {
         self.reshaped.resize(w3 * conv_proj_dim, 0.0);
         self.pe.resize(w3 * d_model, 0.0);
     }
+
+    pub fn ensure_scratch(&mut self, n: usize) {
+        if self.bf16_scratch.len() < n {
+            self.bf16_scratch.resize(n, 0.0);
+        }
+    }
 }
 
 pub struct Encoder {
@@ -123,15 +140,18 @@ pub struct Encoder {
     pub conv2_bias: Vec<f32>,
     pub conv3_weight: Vec<f32>,
     pub conv3_bias: Vec<f32>,
-    pub conv_out_weight: Vec<f32>,
+    pub conv_out_weight_bf16: *const u16,
     pub layers: Vec<EncLayer>,
     pub ln_post_weight: Vec<f32>,
     pub ln_post_bias: Vec<f32>,
-    pub proj1_weight: Vec<f32>,
+    pub proj1_weight_bf16: *const u16,
     pub proj1_bias: Vec<f32>,
-    pub proj2_weight: Vec<f32>,
+    pub proj2_weight_bf16: *const u16,
     pub proj2_bias: Vec<f32>,
 }
+
+unsafe impl Send for Encoder {}
+unsafe impl Sync for Encoder {}
 
 const ENC_PREFIX: &str = "thinker.audio_tower.";
 
@@ -143,38 +163,32 @@ fn load_f32(ms: &MultiSafetensors, name: &str) -> Option<Vec<f32>> {
     result
 }
 
-fn load_bf16_as_f32(ms: &MultiSafetensors, name: &str) -> Option<Vec<f32>> {
-    let (si, t) = ms.find(name).or_else(|| {
+fn load_bf16_direct(ms: &MultiSafetensors, name: &str) -> Option<*const u16> {
+    let ptr = ms.get_bf16_direct(name);
+    if ptr.is_none() {
         eprintln!("encoder: weight not found: {}", name);
-        None
-    })?;
-
-    let bf16_ptr = ms.shards[si].get_bf16_direct(t)?;
-    let n = t.numel();
-    let mut f32_data = vec![0.0f32; n];
-    let src = unsafe { std::slice::from_raw_parts(bf16_ptr, n) };
-    kernels::bf16_to_f32_buf(&mut f32_data, src);
-    Some(f32_data)
+    }
+    ptr
 }
 
-/// Load one encoder transformer layer (bf16->f32 weight conversion). Independent
-/// per layer, so callable in parallel.
+/// Load one encoder transformer layer. All large weight matrices stay as BF16
+/// views into the mmap'd safetensors file (no Vec<f32> upconversion).
 fn load_enc_layer(ms: &MultiSafetensors, i: usize) -> Option<EncLayer> {
     let lp = format!("{}layers.{}", ENC_PREFIX, i);
     Some(EncLayer {
-        wq_weight: load_bf16_as_f32(ms, &format!("{}.self_attn.q_proj.weight", lp))?,
+        wq_weight_bf16: load_bf16_direct(ms, &format!("{}.self_attn.q_proj.weight", lp))?,
         wq_bias: load_f32(ms, &format!("{}.self_attn.q_proj.bias", lp))?,
-        wk_weight: load_bf16_as_f32(ms, &format!("{}.self_attn.k_proj.weight", lp))?,
+        wk_weight_bf16: load_bf16_direct(ms, &format!("{}.self_attn.k_proj.weight", lp))?,
         wk_bias: load_f32(ms, &format!("{}.self_attn.k_proj.bias", lp))?,
-        wv_weight: load_bf16_as_f32(ms, &format!("{}.self_attn.v_proj.weight", lp))?,
+        wv_weight_bf16: load_bf16_direct(ms, &format!("{}.self_attn.v_proj.weight", lp))?,
         wv_bias: load_f32(ms, &format!("{}.self_attn.v_proj.bias", lp))?,
-        wo_weight: load_bf16_as_f32(ms, &format!("{}.self_attn.out_proj.weight", lp))?,
+        wo_weight_bf16: load_bf16_direct(ms, &format!("{}.self_attn.out_proj.weight", lp))?,
         wo_bias: load_f32(ms, &format!("{}.self_attn.out_proj.bias", lp))?,
         attn_norm_weight: load_f32(ms, &format!("{}.self_attn_layer_norm.weight", lp))?,
         attn_norm_bias: load_f32(ms, &format!("{}.self_attn_layer_norm.bias", lp))?,
-        fc1_weight: load_bf16_as_f32(ms, &format!("{}.fc1.weight", lp))?,
+        fc1_weight_bf16: load_bf16_direct(ms, &format!("{}.fc1.weight", lp))?,
         fc1_bias: load_f32(ms, &format!("{}.fc1.bias", lp))?,
-        fc2_weight: load_bf16_as_f32(ms, &format!("{}.fc2.weight", lp))?,
+        fc2_weight_bf16: load_bf16_direct(ms, &format!("{}.fc2.weight", lp))?,
         fc2_bias: load_f32(ms, &format!("{}.fc2.bias", lp))?,
         ffn_norm_weight: load_f32(ms, &format!("{}.final_layer_norm.weight", lp))?,
         ffn_norm_bias: load_f32(ms, &format!("{}.final_layer_norm.bias", lp))?,
@@ -191,10 +205,10 @@ impl Encoder {
         let conv2_bias = load_f32(ms, &format!("{}conv2d2.bias", p))?;
         let conv3_weight = load_f32(ms, &format!("{}conv2d3.weight", p))?;
         let conv3_bias = load_f32(ms, &format!("{}conv2d3.bias", p))?;
-        let conv_out_weight = load_bf16_as_f32(ms, &format!("{}conv_out.weight", p))?;
+        let conv_out_weight_bf16 = load_bf16_direct(ms, &format!("{}conv_out.weight", p))?;
 
-        // Per-layer weights are independent and conversion-heavy (bf16->f32),
-        // so load encoder layers in parallel.
+        // Per-layer "loading" is now nearly free (just pointer + tiny bias reads),
+        // but keep the parallel scaffolding so it stays uniform with the decoder.
         let nlayers = cfg.enc_layers;
         let nthreads = kernels::get_num_cpus().min(nlayers).max(1);
         let chunk = nlayers.div_ceil(nthreads);
@@ -225,9 +239,9 @@ impl Encoder {
 
         let ln_post_weight = load_f32(ms, &format!("{}ln_post.weight", p))?;
         let ln_post_bias = load_f32(ms, &format!("{}ln_post.bias", p))?;
-        let proj1_weight = load_bf16_as_f32(ms, &format!("{}proj1.weight", p))?;
+        let proj1_weight_bf16 = load_bf16_direct(ms, &format!("{}proj1.weight", p))?;
         let proj1_bias = load_f32(ms, &format!("{}proj1.bias", p))?;
-        let proj2_weight = load_bf16_as_f32(ms, &format!("{}proj2.weight", p))?;
+        let proj2_weight_bf16 = load_bf16_direct(ms, &format!("{}proj2.weight", p))?;
         let proj2_bias = load_f32(ms, &format!("{}proj2.bias", p))?;
 
         Some(Encoder {
@@ -237,13 +251,13 @@ impl Encoder {
             conv2_bias,
             conv3_weight,
             conv3_bias,
-            conv_out_weight,
+            conv_out_weight_bf16,
             layers,
             ln_post_weight,
             ln_post_bias,
-            proj1_weight,
+            proj1_weight_bf16,
             proj1_bias,
-            proj2_weight,
+            proj2_weight_bf16,
             proj2_bias,
         })
     }
@@ -302,6 +316,17 @@ impl Encoder {
                 &mut _owned_bufs
             }
         };
+        // Largest BF16 weight matrix the encoder GEMM sees:
+        //   conv_out: conv_proj_dim × d_model      = 7680 × 1024 = ~7.5M
+        //   fc1/fc2:  d_model × ffn_dim            = 1024 × 4096 = ~4.2M
+        //   attn:     d_model × d_model            = 1024 × 1024 = ~1.0M
+        //   proj1/2:  d_model × d_model            = ~1.0M
+        // Sized to the max so conversion only needs one allocation.
+        let conv_proj_dim = CONV_HIDDEN * 16; // h3=16 for chunk_size=100
+        let scratch_n = (conv_proj_dim * d_model)
+            .max(d_model * ffn_dim)
+            .max(d_model * d_model);
+        bufs.ensure_scratch(scratch_n);
 
         // Main sequence buffer: [total_tokens, d_model]
         let td = total_tokens * d_model;
@@ -399,14 +424,18 @@ impl Encoder {
 
             // Project: [w3, 7680] -> [w3, d_model]
             let projected = &mut bufs.x[token_offset * d_model..(token_offset + w3) * d_model];
-            kernels::linear_nobias(
-                projected,
-                reshaped,
-                &self.conv_out_weight,
-                w3,
-                conv_proj_dim,
-                d_model,
-            );
+            unsafe {
+                kernels::linear_bf16_scratch(
+                    projected,
+                    reshaped,
+                    self.conv_out_weight_bf16,
+                    None,
+                    w3,
+                    conv_proj_dim,
+                    d_model,
+                    &mut bufs.bf16_scratch,
+                );
+            }
 
             // Add per-chunk sinusoidal PE
             let pe = &mut bufs.pe[..w3 * d_model];
@@ -441,33 +470,38 @@ impl Encoder {
                 1e-5,
             );
 
-            kernels::linear(
-                &mut bufs.q[..td],
-                &bufs.x_norm[..td],
-                &layer.wq_weight,
-                Some(&layer.wq_bias),
-                total_tokens,
-                d_model,
-                d_model,
-            );
-            kernels::linear(
-                &mut bufs.k[..td],
-                &bufs.x_norm[..td],
-                &layer.wk_weight,
-                Some(&layer.wk_bias),
-                total_tokens,
-                d_model,
-                d_model,
-            );
-            kernels::linear(
-                &mut bufs.v[..td],
-                &bufs.x_norm[..td],
-                &layer.wv_weight,
-                Some(&layer.wv_bias),
-                total_tokens,
-                d_model,
-                d_model,
-            );
+            unsafe {
+                kernels::linear_bf16_scratch(
+                    &mut bufs.q[..td],
+                    &bufs.x_norm[..td],
+                    layer.wq_weight_bf16,
+                    Some(&layer.wq_bias),
+                    total_tokens,
+                    d_model,
+                    d_model,
+                    &mut bufs.bf16_scratch,
+                );
+                kernels::linear_bf16_scratch(
+                    &mut bufs.k[..td],
+                    &bufs.x_norm[..td],
+                    layer.wk_weight_bf16,
+                    Some(&layer.wk_bias),
+                    total_tokens,
+                    d_model,
+                    d_model,
+                    &mut bufs.bf16_scratch,
+                );
+                kernels::linear_bf16_scratch(
+                    &mut bufs.v[..td],
+                    &bufs.x_norm[..td],
+                    layer.wv_weight_bf16,
+                    Some(&layer.wv_bias),
+                    total_tokens,
+                    d_model,
+                    d_model,
+                    &mut bufs.bf16_scratch,
+                );
+            }
 
             kernels::bidirectional_attention(
                 &mut bufs.attn_out[..td],
@@ -483,15 +517,18 @@ impl Encoder {
             );
 
             // Fused: x += wo_bias + attn_out @ wo_weight.T
-            kernels::linear_accumulate(
-                &mut bufs.x[..td],
-                &bufs.attn_out[..td],
-                &layer.wo_weight,
-                Some(&layer.wo_bias),
-                total_tokens,
-                d_model,
-                d_model,
-            );
+            unsafe {
+                kernels::linear_accumulate_bf16_scratch(
+                    &mut bufs.x[..td],
+                    &bufs.attn_out[..td],
+                    layer.wo_weight_bf16,
+                    Some(&layer.wo_bias),
+                    total_tokens,
+                    d_model,
+                    d_model,
+                    &mut bufs.bf16_scratch,
+                );
+            }
 
             // FFN
             kernels::layer_norm(
@@ -504,26 +541,32 @@ impl Encoder {
                 1e-5,
             );
 
-            kernels::linear(
-                &mut bufs.ffn_mid[..tf],
-                &bufs.x_norm[..td],
-                &layer.fc1_weight,
-                Some(&layer.fc1_bias),
-                total_tokens,
-                d_model,
-                ffn_dim,
-            );
+            unsafe {
+                kernels::linear_bf16_scratch(
+                    &mut bufs.ffn_mid[..tf],
+                    &bufs.x_norm[..td],
+                    layer.fc1_weight_bf16,
+                    Some(&layer.fc1_bias),
+                    total_tokens,
+                    d_model,
+                    ffn_dim,
+                    &mut bufs.bf16_scratch,
+                );
+            }
             kernels::gelu(&mut bufs.ffn_mid[..tf], tf);
             // Fused: x += fc2_bias + ffn_mid @ fc2_weight.T
-            kernels::linear_accumulate(
-                &mut bufs.x[..td],
-                &bufs.ffn_mid[..tf],
-                &layer.fc2_weight,
-                Some(&layer.fc2_bias),
-                total_tokens,
-                ffn_dim,
-                d_model,
-            );
+            unsafe {
+                kernels::linear_accumulate_bf16_scratch(
+                    &mut bufs.x[..td],
+                    &bufs.ffn_mid[..tf],
+                    layer.fc2_weight_bf16,
+                    Some(&layer.fc2_bias),
+                    total_tokens,
+                    ffn_dim,
+                    d_model,
+                    &mut bufs.bf16_scratch,
+                );
+            }
         }
 
         // Final LayerNorm: use x_norm as temp, then swap into x
@@ -539,27 +582,33 @@ impl Encoder {
         bufs.x[..td].copy_from_slice(&bufs.x_norm[..td]);
 
         // Projection: proj1 (GELU) -> proj2 (reuse scratch buffers)
-        kernels::linear(
-            &mut bufs.q[..td],
-            &bufs.x[..td],
-            &self.proj1_weight,
-            Some(&self.proj1_bias),
-            total_tokens,
-            d_model,
-            d_model,
-        );
+        unsafe {
+            kernels::linear_bf16_scratch(
+                &mut bufs.q[..td],
+                &bufs.x[..td],
+                self.proj1_weight_bf16,
+                Some(&self.proj1_bias),
+                total_tokens,
+                d_model,
+                d_model,
+                &mut bufs.bf16_scratch,
+            );
+        }
         kernels::gelu(&mut bufs.q[..td], td);
 
         let mut enc_output = vec![0.0f32; total_tokens * output_dim];
-        kernels::linear(
-            &mut enc_output,
-            &bufs.q[..td],
-            &self.proj2_weight,
-            Some(&self.proj2_bias),
-            total_tokens,
-            d_model,
-            output_dim,
-        );
+        unsafe {
+            kernels::linear_bf16_scratch(
+                &mut enc_output,
+                &bufs.q[..td],
+                self.proj2_weight_bf16,
+                Some(&self.proj2_bias),
+                total_tokens,
+                d_model,
+                output_dim,
+                &mut bufs.bf16_scratch,
+            );
+        }
 
         Some((enc_output, total_tokens))
     }

--- a/crates/qwen-asr/src/kernels/mod.rs
+++ b/crates/qwen-asr/src/kernels/mod.rs
@@ -716,6 +716,33 @@ pub fn linear_bf16(y: &mut [f32], x: &[f32], w_bf16: *const u16, b: Option<&[f32
     linear(y, x, &w_f32, b, seq_len, in_dim, out_dim);
 }
 
+/// Bias-supporting variant of `linear_nobias_bf16_scratch`: streams a BF16 weight
+/// matrix through a caller-provided f32 scratch buffer instead of allocating.
+/// # Safety
+/// Caller must ensure `w_bf16` points to at least `out_dim * in_dim` valid bf16 values.
+pub unsafe fn linear_bf16_scratch(y: &mut [f32], x: &[f32], w_bf16: *const u16, b: Option<&[f32]>, seq_len: usize, in_dim: usize, out_dim: usize, scratch: &mut [f32]) {
+    let _pg = ProfileGuard::new(&PROF.bf16_matvec);
+    if seq_len == 1 {
+        bf16_matvec_threaded(y, x, w_bf16, b, in_dim, out_dim);
+        return;
+    }
+    let n = out_dim * in_dim;
+    let src = unsafe { std::slice::from_raw_parts(w_bf16, n) };
+    bf16_to_f32_buf(&mut scratch[..n], src);
+    linear(y, x, &scratch[..n], b, seq_len, in_dim, out_dim);
+}
+
+/// y += bias + x @ w_bf16.T  — bias optional, BF16 weights streamed through scratch.
+/// # Safety
+/// Caller must ensure `w_bf16` points to at least `out_dim * in_dim` valid bf16 values.
+pub unsafe fn linear_accumulate_bf16_scratch(y: &mut [f32], x: &[f32], w_bf16: *const u16, b: Option<&[f32]>, seq_len: usize, in_dim: usize, out_dim: usize, scratch: &mut [f32]) {
+    let _pg = ProfileGuard::new(&PROF.bf16_matvec);
+    let n = out_dim * in_dim;
+    let src = unsafe { std::slice::from_raw_parts(w_bf16, n) };
+    bf16_to_f32_buf(&mut scratch[..n], src);
+    linear_accumulate(y, x, &scratch[..n], b, seq_len, in_dim, out_dim);
+}
+
 /// Fused Q/K/V matvec for single-token decode
 #[allow(clippy::too_many_arguments)]
 pub fn linear_nobias_bf16_qkv(
@@ -1369,6 +1396,72 @@ pub fn swiglu_multiply(out: &mut [f32], gate_up: &[f32], seq_len: usize, interme
             let g_silu = g / (1.0 + (-g).exp());
             o[j] = g_silu * u;
         }
+    }
+}
+
+/// SwiGLU in place: `gate[i] = silu(gate[i]) * up[i]`. Reads `up` and overwrites
+/// `gate` with the final activation, avoiding an extra output buffer.
+pub fn swiglu_separate_inplace(gate: &mut [f32], up: &[f32], seq_len: usize, intermediate: usize) {
+    let _pg = ProfileGuard::new(&PROF.swiglu);
+    let total = seq_len * intermediate;
+    let n_threads = get_num_threads();
+
+    if n_threads > 1 && total > 4096 {
+        let gate_ptr = gate.as_mut_ptr() as usize;
+        let up_ptr = up.as_ptr() as usize;
+        parallel_for(|tid, nt| {
+            let chunk = total.div_ceil(nt);
+            let start = tid * chunk;
+            let end = (start + chunk).min(total);
+            if start >= end { return; }
+            let g = unsafe { std::slice::from_raw_parts_mut((gate_ptr as *mut f32).add(start), end - start) };
+            let u = unsafe { std::slice::from_raw_parts((up_ptr as *const f32).add(start), end - start) };
+            for j in 0..(end - start) {
+                let gv = g[j];
+                g[j] = gv / (1.0 + (-gv).exp()) * u[j];
+            }
+        });
+        return;
+    }
+
+    for j in 0..total {
+        let gv = gate[j];
+        gate[j] = gv / (1.0 + (-gv).exp()) * up[j];
+    }
+}
+
+/// SwiGLU with gate and up provided as separate (non-interleaved) tensors.
+/// `out[i] = silu(gate[i]) * up[i]`, all sized `seq_len * intermediate`.
+pub fn swiglu_separate(out: &mut [f32], gate: &[f32], up: &[f32], seq_len: usize, intermediate: usize) {
+    let _pg = ProfileGuard::new(&PROF.swiglu);
+    let total = seq_len * intermediate;
+    let n_threads = get_num_threads();
+
+    if n_threads > 1 && total > 4096 {
+        let out_ptr = out.as_mut_ptr() as usize;
+        let gate_ptr = gate.as_ptr() as usize;
+        let up_ptr = up.as_ptr() as usize;
+        parallel_for(|tid, nt| {
+            let chunk = total.div_ceil(nt);
+            let start = tid * chunk;
+            let end = (start + chunk).min(total);
+            if start >= end { return; }
+            let o = unsafe { std::slice::from_raw_parts_mut((out_ptr as *mut f32).add(start), end - start) };
+            let g = unsafe { std::slice::from_raw_parts((gate_ptr as *const f32).add(start), end - start) };
+            let u = unsafe { std::slice::from_raw_parts((up_ptr as *const f32).add(start), end - start) };
+            for j in 0..(end - start) {
+                let gv = g[j];
+                let uv = u[j];
+                o[j] = gv / (1.0 + (-gv).exp()) * uv;
+            }
+        });
+        return;
+    }
+
+    for j in 0..total {
+        let g = gate[j];
+        let u = up[j];
+        out[j] = g / (1.0 + (-g).exp()) * u;
     }
 }
 


### PR DESCRIPTION
I think this pr can be improved but I needed to run the aligner on a iphone 17. Processed died because it took too much memory with increased memory entitlement. This code fixes that coz it successfully aligns on iphone 17 without crashing. 

I ran tests locally and all passed. From what I understand these changes could benefit reduced memory consumption across all platforms. I think also this work may relate to https://github.com/huanglizhuo/QwenASR/blob/main/unchecked-ideas.md

---

The loader previously upconverted every BF16 weight tensor into an owned Vec<f32> at startup and the decoder kept INT8 + interleaved bf16 fusion copies on top. On Qwen3-ForcedAligner-0.6B that came out to ~4.5 GB of heap — fine on a workstation, jetsam-killed on iPhone even with the increased-memory-limit entitlement.

Encoder weights are now *const u16 views into the mmap'd safetensors; EncoderBuffers gains a shared bf16_scratch and each GEMM streams its weights through that one f32 buffer.

Decoder drops the seven _f32_prefill copies. For aligner configs — which only run prefill — it additionally skips INT8 quantization and the owned gate_up_fused_bf16; the prefill MLP runs split gate/up BF16 GEMMs followed by swiglu_separate_inplace. ASR single-token decode path is untouched.

Kernels add linear_bf16_scratch, linear_accumulate_bf16_scratch, and swiglu_separate_inplace.

Measured on Qwen3-ForcedAligner-0.6B (aarch64 macOS, /usr/bin/time -l):
  peak memory footprint   4.54 GB → 0.71 GB   (6.4× less)
  model load              397 ms  → 60 ms     (6.5× faster)
  alignment latency       745 ms  → 736 ms    (unchanged)
  alignment output        bit-identical to baseline

Builds clean for aarch64-apple-ios and aarch64-apple-ios-sim.