### PR TITLE
fix: harden encoder BF16 scratch sizing for proj2

### DIFF
--- a/crates/qwen-asr/src/encoder.rs
+++ b/crates/qwen-asr/src/encoder.rs
@@ -316,16 +316,20 @@ impl Encoder {
                 &mut _owned_bufs
             }
         };
-        // Largest BF16 weight matrix the encoder GEMM sees:
-        //   conv_out: conv_proj_dim × d_model      = 7680 × 1024 = ~7.5M
-        //   fc1/fc2:  d_model × ffn_dim            = 1024 × 4096 = ~4.2M
-        //   attn:     d_model × d_model            = 1024 × 1024 = ~1.0M
-        //   proj1/2:  d_model × d_model            = ~1.0M
-        // Sized to the max so conversion only needs one allocation.
-        let conv_proj_dim = CONV_HIDDEN * 16; // h3=16 for chunk_size=100
+        // Largest BF16 weight matrix the encoder GEMM streams through scratch:
+        //   conv_out:  conv_proj_dim × d_model     = 7680 × 1024 = ~7.5M
+        //   fc1/fc2:   d_model × ffn_dim           = 1024 × 4096 = ~4.2M
+        //   attn:      d_model × d_model           = 1024 × 1024 = ~1.0M
+        //   proj1:     d_model × d_model
+        //   proj2:     output_dim × d_model        (output_dim = dec_hidden, can exceed d_model)
+        // Sized to the max so conversion only needs one allocation. h3 is the
+        // post-conv frequency dim (128 mel bins → 16 after the conv stem), fixed
+        // by the architecture and independent of chunk size.
+        let conv_proj_dim = CONV_HIDDEN * 16; // h3 = 16
         let scratch_n = (conv_proj_dim * d_model)
             .max(d_model * ffn_dim)
-            .max(d_model * d_model);
+            .max(d_model * d_model)
+            .max(output_dim * d_model);
         bufs.ensure_scratch(scratch_n);
 
         // Main sequence buffer: [total_tokens, d_model]

--- a/crates/qwen-asr/src/kernels/mod.rs
+++ b/crates/qwen-asr/src/kernels/mod.rs
@@ -720,6 +720,7 @@ pub fn linear_bf16(y: &mut [f32], x: &[f32], w_bf16: *const u16, b: Option<&[f32
 /// matrix through a caller-provided f32 scratch buffer instead of allocating.
 /// # Safety
 /// Caller must ensure `w_bf16` points to at least `out_dim * in_dim` valid bf16 values.
+#[allow(clippy::too_many_arguments)]
 pub unsafe fn linear_bf16_scratch(y: &mut [f32], x: &[f32], w_bf16: *const u16, b: Option<&[f32]>, seq_len: usize, in_dim: usize, out_dim: usize, scratch: &mut [f32]) {
     let _pg = ProfileGuard::new(&PROF.bf16_matvec);
     if seq_len == 1 {
@@ -735,6 +736,7 @@ pub unsafe fn linear_bf16_scratch(y: &mut [f32], x: &[f32], w_bf16: *const u16, 
 /// y += bias + x @ w_bf16.T  — bias optional, BF16 weights streamed through scratch.
 /// # Safety
 /// Caller must ensure `w_bf16` points to at least `out_dim * in_dim` valid bf16 values.
+#[allow(clippy::too_many_arguments)]
 pub unsafe fn linear_accumulate_bf16_scratch(y: &mut [f32], x: &[f32], w_bf16: *const u16, b: Option<&[f32]>, seq_len: usize, in_dim: usize, out_dim: usize, scratch: &mut [f32]) {
     let _pg = ProfileGuard::new(&PROF.bf16_matvec);
     let n = out_dim * in_dim;


### PR DESCRIPTION
Follow-up hardening on top of #32 (the BF16 mmap-view change that cut aligner peak memory ~6.4× — 4.54 GB → 0.70 GB).

## Changes
1. **Encoder scratch bound** — `bufs.ensure_scratch(...)` now explicitly includes `output_dim * d_model` (the proj2 matrix). Previously the size relied on `conv_out` (`conv_proj_dim × d_model`) always being the largest matrix streamed through scratch. Since `output_dim = dec_hidden` can exceed `d_model` (e.g. 1024 > 896 on the 0.6B ASR small encoder), this makes the proj2 bound explicit and rules out a future out-of-bounds into the scratch slice. No behavior change on current models (conv_out still dominates), just defensive.
2. **Clippy** — added `#[allow(clippy::too_many_arguments)]` to `linear_bf16_scratch` and `linear_accumulate_bf16_scratch` (8 args each), matching the convention of the 11 other BF16 kernels in the same file.

## Verification
- `cargo build --release`: zero rustc warnings
- `cargo test --release`: all pass
- Aligner output on the sample: **bit-identical** to pre-change

🤖 Generated with [Claude Code](https://claude.com/claude-code)