### PR TITLE
fix: repair release-please workspace Cargo.toml version sync

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,9 @@ edition = "2021"
 license = "MIT"
 
 [workspace.dependencies]
-# x-release-please-version
+# x-release-please-start-version
 qwen-asr = { version = "0.7.2", path = "crates/qwen-asr" }
+# x-release-please-end
 
 [profile.release]
 opt-level = 3

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,13 +2,7 @@
   "packages": {
     "crates/qwen-asr": {
       "release-type": "rust",
-      "component": "qwen-asr",
-      "extra-files": [
-        {
-          "type": "generic",
-          "path": "../../Cargo.toml"
-        }
-      ]
+      "component": "qwen-asr"
     },
     "crates/qwen-asr-cli": {
       "release-type": "rust",
@@ -18,5 +12,11 @@
       "release-type": "dart",
       "component": "qwen_asr"
     }
-  }
+  },
+  "extra-files": [
+    {
+      "type": "generic",
+      "path": "Cargo.toml"
+    }
+  ]
 }


### PR DESCRIPTION
The release-please workflow has been failing on every push to `main` with:

```
release-please failed: illegal pathing characters in path: crates/qwen-asr/../../Cargo.toml
```

so no release PR / CHANGELOG was being generated (e.g. it blocked the release for #32/#33).

## Root cause (two bugs)
1. **Illegal path** — the root `Cargo.toml` updater lived in the `crates/qwen-asr` *package* config, whose `extra-files` paths are resolved **relative to the package dir**. `../../Cargo.toml` became `crates/qwen-asr/../../Cargo.toml`, and release-please rejects the leading `..`.
2. **Marker never matched** — the inline `x-release-please-version` annotation only replaces a version **on its own line**, but the comment sat on the line *above* `qwen-asr = { version = "..." }`. So even when the path was right, the version was never replaced — which is why the workspace dependency had to be bumped by hand every release (`fix: sync workspace dependency for release`, etc.).

## Fix
- Move the `Cargo.toml` updater to **top-level** `extra-files` (repo-root relative path → no `..`).
- Convert the root `Cargo.toml` marker to a `x-release-please-start-version` / `x-release-please-end` **block** so the version is actually replaced.

## Result
release-please can now build the release PR, and the root `[workspace.dependencies] qwen-asr` version stays in sync automatically (no more manual bumps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)