### PR TITLE
fix: auto-sync qwen-asr version into qwen-asr-cli via cargo-workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,11 +8,6 @@ version = "0.1.2"
 edition = "2021"
 license = "MIT"
 
-[workspace.dependencies]
-# x-release-please-start-version
-qwen-asr = { version = "0.7.2", path = "crates/qwen-asr" }
-# x-release-please-end
-
 [profile.release]
 opt-level = 3
 lto = "fat"

--- a/crates/qwen-asr-cli/Cargo.toml
+++ b/crates/qwen-asr-cli/Cargo.toml
@@ -15,7 +15,7 @@ name = "qwen-asr"
 path = "src/main.rs"
 
 [dependencies]
-qwen-asr = { workspace = true }
+qwen-asr = { version = "0.7.2", path = "../qwen-asr" }
 ureq = "2"
 ctrlc = "3"
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -13,10 +13,7 @@
       "component": "qwen_asr"
     }
   },
-  "extra-files": [
-    {
-      "type": "generic",
-      "path": "Cargo.toml"
-    }
+  "plugins": [
+    "cargo-workspace"
   ]
 }


### PR DESCRIPTION
Makes the workspace version sync actually automatic, following up on #34.

## Why
The root `[workspace.dependencies]` version of `qwen-asr` could never be kept in sync by release-please:
- The `cargo-workspace` plugin does **not** understand `workspace = true` inheritance (it only updates direct `[dependencies]` version fields + `Cargo.lock`).
- A generic `extra-files` updater on the root `Cargo.toml` never fires for a sub-component release (top-level `extra-files` only run for a root `.` package).

That's why every release historically needed a manual `fix: sync workspace dependency` commit.

## Change
Switch to the standard release-please cargo-workspace pattern:
- `qwen-asr-cli` depends on `qwen-asr` via a direct `{ version = "0.7.2", path = "../qwen-asr" }` dep instead of workspace inheritance, so the plugin can manage that version.
- Enable the `cargo-workspace` plugin.
- Drop the now-unused root `[workspace.dependencies]` entry and the non-functional top-level `extra-files`.

## Effect
Each `qwen-asr` release now auto-bumps the cli's dependency version, patch-bumps the cli, and updates `Cargo.lock` — and the cli is published alongside qwen-asr (correct workspace behavior).

Verified locally: `cargo metadata` resolves (version matches), `cargo build --release` clean, `Cargo.lock` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)