### PR TITLE
fix(x86): stop issuing concurrent cblas_sgemm from the thread pool on non-Apple BLAS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,12 +88,13 @@ jobs:
       - name: Test (no default features)
         run: cargo test --release --no-default-features
 
-  # Issue #47: pool-slicing the conv-stem GEMM is an Accelerate workaround that
-  # becomes a large pessimization on a BLAS that threads internally (OpenBLAS),
-  # because every slice re-packs the whole shared `cols` operand. This runs the
-  # stem's real shapes both ways on both vendors so the gating stays honest
-  # without needing the 1.2GB model. Informational: it prints a comparison and
-  # does not fail the build, since hosted-runner timings are noisy.
+  # Issue #47: several kernels have N pool threads each call `cblas_sgemm`
+  # concurrently. That is safe on Accelerate and is what makes the pool useful
+  # there, but stock OpenBLAS needs USE_LOCKING=1 for concurrent entry and
+  # Ubuntu's package lacks it -- observed as an outright hang, and on a rerun as
+  # a 2.6x slowdown, so it is intermittent. This exercises all three such sites
+  # on both vendors, model-free. Informational: hosted-runner timings are noisy
+  # and the hang is a race, so this exhibits the problem rather than gating on it.
   conv-stem-bench:
     strategy:
       fail-fast: false
@@ -130,7 +131,7 @@ jobs:
 
       # Build first so a slow build can never be mistaken for a slow benchmark.
       - name: Build benchmark
-        run: cargo test --release --no-run --test conv_stem_bench
+        run: cargo test --release --no-run --test gemm_pooling_bench
 
       # Each configuration gets its own hard timeout. The first run of this job
       # hung for 66 min on ubuntu-latest under `QASR_CONV_POOLED=1` while the
@@ -140,20 +141,23 @@ jobs:
       # if slicing only completes with OpenBLAS threading disabled, the problem
       # is concurrent entry into a BLAS whose thread server is not reentrant
       # (stock OpenBLAS needs USE_LOCKING=1 for that), not just cache pressure.
-      - name: Conv-stem GEMM, pool-sliced vs single BLAS call
-        timeout-minutes: 25
+      - name: GEMM pool-slicing, sliced vs single BLAS call
+        # Budget: 8 configs x 180 s worst case = 24 min, under this ceiling. Keep
+        # these two numbers consistent when adding configs, or GitHub kills the
+        # step mid-run and the partial results are lost.
+        timeout-minutes: 30
         run: |
-          bin=$(cargo test --release --no-run --test conv_stem_bench \
+          bin=$(cargo test --release --no-run --test gemm_pooling_bench \
                   --message-format=json 2>/dev/null \
-                | sed -n 's/.*"executable":"\([^"]*conv_stem_bench[^"]*\)".*/\1/p' | head -1)
+                | sed -n 's/.*"executable":"\([^"]*gemm_pooling_bench[^"]*\)".*/\1/p' | head -1)
           echo "bench binary: $bin"
 
           # `timeout` is GNU coreutils; macOS runners have neither it nor
           # gtimeout unless brew coreutils is installed. Degrade to no timeout
           # there — the hang only reproduces on the Linux leg anyway, and the
           # job-level timeout-minutes still bounds it.
-          if command -v timeout >/dev/null 2>&1; then TO="timeout -s KILL 300"
-          elif command -v gtimeout >/dev/null 2>&1; then TO="gtimeout -s KILL 300"
+          if command -v timeout >/dev/null 2>&1; then TO="timeout -s KILL 180"
+          elif command -v gtimeout >/dev/null 2>&1; then TO="gtimeout -s KILL 180"
           else TO=""; echo "note: no timeout(1) available, running unbounded"; fi
 
           # $1 label, $2 test name, $3 knob env, $4 slicing 0/1,
@@ -176,12 +180,17 @@ jobs:
 
           C=conv_stem_gemm_bench
           L=linear_gemm_bench
+          A=causal_attention_prefill_bench
           run conv-sliced      $C QASR_CONV_POOLED   1 ""
           run conv-single      $C QASR_CONV_POOLED   0 ""
           run conv-sliced-obt1 $C QASR_CONV_POOLED   1 1
           run conv-single-obt1 $C QASR_CONV_POOLED   0 1
           run lin-sliced       $L QASR_LINEAR_POOLED 1 ""
           run lin-single       $L QASR_LINEAR_POOLED 0 ""
+          # The ungated third site: head-parallel prefill attention. QASR_ATTN_THREADS=1
+          # is the serial reference -- one thread in BLAS at a time.
+          run attn-parallel    $A QASR_ATTN_THREADS  "" ""
+          run attn-serial      $A QASR_ATTN_THREADS  1  ""
 
           total() {
             local v
@@ -199,6 +208,8 @@ jobs:
             echo "| conv stem | no | 1 | $(total conv-single-obt1) |"
             echo "| linear | yes | default | $(total lin-sliced) |"
             echo "| linear | no | default | $(total lin-single) |"
+            echo "| prefill attention (**ungated**) | yes | default | $(total attn-parallel) |"
+            echo "| prefill attention | serial ref | default | $(total attn-serial) |"
             echo ""
             echo "A HANG in a sliced row is the result, not a flake: concurrent"
             echo "\`cblas_sgemm\` entry is unsupported on stock OpenBLAS"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,10 +187,10 @@ jobs:
           run conv-single-obt1 $C QASR_CONV_POOLED   0 1
           run lin-sliced       $L QASR_LINEAR_POOLED 1 ""
           run lin-single       $L QASR_LINEAR_POOLED 0 ""
-          # The ungated third site: head-parallel prefill attention. QASR_ATTN_THREADS=1
-          # is the serial reference -- one thread in BLAS at a time.
-          run attn-parallel    $A QASR_ATTN_THREADS  "" ""
-          run attn-serial      $A QASR_ATTN_THREADS  1  ""
+          # Third site: head-parallel prefill attention. Sliced = N threads in
+          # BLAS at once; single = one caller, BLAS threads each per-head GEMM.
+          run attn-sliced      $A QASR_ATTN_POOLED   1 ""
+          run attn-single      $A QASR_ATTN_POOLED   0 ""
 
           total() {
             local v
@@ -208,8 +208,8 @@ jobs:
             echo "| conv stem | no | 1 | $(total conv-single-obt1) |"
             echo "| linear | yes | default | $(total lin-sliced) |"
             echo "| linear | no | default | $(total lin-single) |"
-            echo "| prefill attention (**ungated**) | yes | default | $(total attn-parallel) |"
-            echo "| prefill attention | serial ref | default | $(total attn-serial) |"
+            echo "| prefill attention | yes | default | $(total attn-sliced) |"
+            echo "| prefill attention | no | default | $(total attn-single) |"
             echo ""
             echo "A HANG in a sliced row is the result, not a flake: concurrent"
             echo "\`cblas_sgemm\` entry is unsupported on stock OpenBLAS"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,29 +128,68 @@ jobs:
             ldconfig -p | grep -i openblas | head -2
           fi
 
-      - name: Conv-stem GEMM, pool-sliced vs single BLAS call
-        run: |
-          set -o pipefail
-          run() {
-            QASR_CONV_POOLED="$1" cargo test --release --test conv_stem_bench \
-              -- --ignored --nocapture 2>&1 | tee "/tmp/pooled-$1.log"
-          }
-          echo "::group::pool-sliced (QASR_CONV_POOLED=1)"
-          run 1
-          echo "::endgroup::"
-          echo "::group::single BLAS call (QASR_CONV_POOLED=0)"
-          run 0
-          echo "::endgroup::"
+      # Build first so a slow build can never be mistaken for a slow benchmark.
+      - name: Build benchmark
+        run: cargo test --release --no-run --test conv_stem_bench
 
-          sliced=$(grep BENCH_TOTAL_MS /tmp/pooled-1.log | awk '{print $2}')
-          single=$(grep BENCH_TOTAL_MS /tmp/pooled-0.log | awk '{print $2}')
+      # Each configuration gets its own hard timeout. The first run of this job
+      # hung for 66 min on ubuntu-latest under `QASR_CONV_POOLED=1` while the
+      # same step took 18 s on macos-latest, so a hang is a plausible outcome
+      # here and must be recorded rather than allowed to stall the workflow.
+      # `OPENBLAS_NUM_THREADS=1` is included to separate two candidate causes:
+      # if slicing only completes with OpenBLAS threading disabled, the problem
+      # is concurrent entry into a BLAS whose thread server is not reentrant
+      # (stock OpenBLAS needs USE_LOCKING=1 for that), not just cache pressure.
+      - name: Conv-stem GEMM, pool-sliced vs single BLAS call
+        timeout-minutes: 25
+        run: |
+          bin=$(cargo test --release --no-run --test conv_stem_bench \
+                  --message-format=json 2>/dev/null \
+                | sed -n 's/.*"executable":"\([^"]*conv_stem_bench[^"]*\)".*/\1/p' | head -1)
+          echo "bench binary: $bin"
+
+          # `timeout` is GNU coreutils; macOS runners have neither it nor
+          # gtimeout unless brew coreutils is installed. Degrade to no timeout
+          # there — the hang only reproduces on the Linux leg anyway, and the
+          # job-level timeout-minutes still bounds it.
+          if command -v timeout >/dev/null 2>&1; then TO="timeout -s KILL 300"
+          elif command -v gtimeout >/dev/null 2>&1; then TO="gtimeout -s KILL 300"
+          else TO=""; echo "note: no timeout(1) available, running unbounded"; fi
+
+          # $1 label, $2 QASR_CONV_POOLED, $3 OPENBLAS_NUM_THREADS ("" = default)
+          run() {
+            local label=$1 pooled=$2 obt=$3 log="/tmp/bench-$1.log"
+            echo "::group::$label (QASR_CONV_POOLED=$pooled OPENBLAS_NUM_THREADS=${obt:-default})"
+            if env QASR_CONV_POOLED="$pooled" ${obt:+OPENBLAS_NUM_THREADS=$obt} \
+                 $TO "$bin" --ignored --nocapture 2>&1 | tee "$log"; then
+              :
+            else
+              echo "TIMED_OUT_OR_FAILED (exit $?)" | tee -a "$log"
+            fi
+            echo "::endgroup::"
+          }
+
+          run sliced        1 ""
+          run single        0 ""
+          run sliced-obt1   1 1
+          run single-obt1   0 1
+
+          total() {
+            local v
+            v=$(grep -h BENCH_TOTAL_MS "/tmp/bench-$1.log" 2>/dev/null | awk '{print $2}' | head -1)
+            echo "${v:-timeout/fail}"
+          }
           {
-            echo "### Conv-stem GEMM — ${{ matrix.os }}"
+            echo "### Conv-stem GEMM — ${{ matrix.os }} ($(uname -m), $(getconf _NPROCESSORS_ONLN) cores)"
             echo ""
-            echo "| pool-sliced (Accelerate policy) | single BLAS call | ratio |"
+            echo "| config | OpenBLAS threads | total |"
             echo "|---|---|---|"
-            echo "| ${sliced} ms | ${single} ms | $(awk "BEGIN{printf \"%.2fx\", ${sliced}/${single}}") |"
+            echo "| pool-sliced (Accelerate policy) | default | $(total sliced) ms |"
+            echo "| single BLAS call | default | $(total single) ms |"
+            echo "| pool-sliced | 1 | $(total sliced-obt1) ms |"
+            echo "| single BLAS call | 1 | $(total single-obt1) ms |"
             echo ""
-            echo "Ratio > 1 means slicing is *slower* here, i.e. this vendor"
-            echo "should take the single-call path (the #47 gating)."
+            echo "A timeout in the pool-sliced rows is itself the result: issuing"
+            echo "concurrent \`cblas_sgemm\` calls from our pool is only safe on a"
+            echo "BLAS built for it, which is exactly what #47 gates off."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,31 @@ jobs:
             ldconfig -p | grep -i openblas | head -2
           fi
 
+      # Publishes an absolute reference for bench/blas_concurrency_repro.c on a
+      # known-good OpenBLAS. #47's reporter is ~12x slower per conv call than
+      # this 4-core runner even in the arrangement that is healthy here, which
+      # concurrency alone cannot explain -- a slow BLAS build (no DYNAMIC_ARCH,
+      # no Zen kernel) would. The ratio tells him whether concurrent entry hurts;
+      # these absolute numbers tell him whether his BLAS is slow to begin with.
+      - name: BLAS concurrent-entry repro (reference numbers)
+        timeout-minutes: 10
+        run: |
+          if [ "$(uname -s)" = "Darwin" ]; then
+            clang -O2 -w bench/blas_concurrency_repro.c -o /tmp/repro -framework Accelerate
+          else
+            gcc -O2 -w bench/blas_concurrency_repro.c -o /tmp/repro -lopenblas -lpthread
+          fi
+          # Bounded: config B is the one that can wedge on a non-reentrant BLAS.
+          if command -v timeout >/dev/null 2>&1; then TO="timeout -s KILL 240"; else TO=""; fi
+          $TO /tmp/repro | tee /tmp/repro.log || echo "TIMED_OUT_OR_FAILED rc=$?"
+          {
+            echo "### BLAS concurrent-entry repro — ${{ matrix.os }}"
+            echo ""
+            echo '```'
+            cat /tmp/repro.log
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
       # Build first so a slow build can never be mistaken for a slow benchmark.
       - name: Build benchmark
         run: cargo test --release --no-run --test gemm_pooling_bench

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,12 +129,14 @@ jobs:
             ldconfig -p | grep -i openblas | head -2
           fi
 
-      # Publishes an absolute reference for bench/blas_concurrency_repro.c on a
-      # known-good OpenBLAS. #47's reporter is ~12x slower per conv call than
-      # this 4-core runner even in the arrangement that is healthy here, which
-      # concurrency alone cannot explain -- a slow BLAS build (no DYNAMIC_ARCH,
-      # no Zen kernel) would. The ratio tells him whether concurrent entry hurts;
-      # these absolute numbers tell him whether his BLAS is slow to begin with.
+      # Publishes reference numbers for bench/blas_concurrency_repro.c. Only its
+      # column A (one thread, one full-width sgemm) is load-bearing: it measures
+      # raw BLAS throughput at the shape that dominates the encoder, which is the
+      # open half of #47 -- the reporter is ~12x slower per conv call than this
+      # runner even in the arrangement that is healthy here. The B/A ratio is NOT
+      # a reliable hang detector: config B completes here every time while the
+      # gemm_pooling_bench conv-sliced config on this same runner hangs in 4 of 5
+      # runs, so the repro does not reproduce what it was written to isolate.
       - name: BLAS concurrent-entry repro (reference numbers)
         timeout-minutes: 10
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,3 +87,70 @@ jobs:
 
       - name: Test (no default features)
         run: cargo test --release --no-default-features
+
+  # Issue #47: pool-slicing the conv-stem GEMM is an Accelerate workaround that
+  # becomes a large pessimization on a BLAS that threads internally (OpenBLAS),
+  # because every slice re-packs the whole shared `cols` operand. This runs the
+  # stem's real shapes both ways on both vendors so the gating stays honest
+  # without needing the 1.2GB model. Informational: it prints a comparison and
+  # does not fail the build, since hosted-runner timings are noisy.
+  conv-stem-bench:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install OpenBLAS (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libopenblas-dev
+
+      - name: Set target-cpu (Linux)
+        if: runner.os == 'Linux'
+        run: echo "RUSTFLAGS=-C target-cpu=x86-64-v3" >> "$GITHUB_ENV"
+
+      - name: Report machine
+        run: |
+          echo "os=${{ matrix.os }} arch=$(uname -m)"
+          if [ "$(uname -s)" = "Darwin" ]; then
+            sysctl -n machdep.cpu.brand_string hw.physicalcpu hw.logicalcpu
+          else
+            nproc && grep -m1 'model name' /proc/cpuinfo
+            ldconfig -p | grep -i openblas | head -2
+          fi
+
+      - name: Conv-stem GEMM, pool-sliced vs single BLAS call
+        run: |
+          set -o pipefail
+          run() {
+            QASR_CONV_POOLED="$1" cargo test --release --test conv_stem_bench \
+              -- --ignored --nocapture 2>&1 | tee "/tmp/pooled-$1.log"
+          }
+          echo "::group::pool-sliced (QASR_CONV_POOLED=1)"
+          run 1
+          echo "::endgroup::"
+          echo "::group::single BLAS call (QASR_CONV_POOLED=0)"
+          run 0
+          echo "::endgroup::"
+
+          sliced=$(grep BENCH_TOTAL_MS /tmp/pooled-1.log | awk '{print $2}')
+          single=$(grep BENCH_TOTAL_MS /tmp/pooled-0.log | awk '{print $2}')
+          {
+            echo "### Conv-stem GEMM — ${{ matrix.os }}"
+            echo ""
+            echo "| pool-sliced (Accelerate policy) | single BLAS call | ratio |"
+            echo "|---|---|---|"
+            echo "| ${sliced} ms | ${single} ms | $(awk "BEGIN{printf \"%.2fx\", ${sliced}/${single}}") |"
+            echo ""
+            echo "Ratio > 1 means slicing is *slower* here, i.e. this vendor"
+            echo "should take the single-call path (the #47 gating)."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,40 +156,51 @@ jobs:
           elif command -v gtimeout >/dev/null 2>&1; then TO="gtimeout -s KILL 300"
           else TO=""; echo "note: no timeout(1) available, running unbounded"; fi
 
-          # $1 label, $2 QASR_CONV_POOLED, $3 OPENBLAS_NUM_THREADS ("" = default)
+          # $1 label, $2 test name, $3 knob env, $4 slicing 0/1,
+          # $5 OPENBLAS_NUM_THREADS ("" = library default)
           run() {
-            local label=$1 pooled=$2 obt=$3 log="/tmp/bench-$1.log"
-            echo "::group::$label (QASR_CONV_POOLED=$pooled OPENBLAS_NUM_THREADS=${obt:-default})"
-            if env QASR_CONV_POOLED="$pooled" ${obt:+OPENBLAS_NUM_THREADS=$obt} \
-                 $TO "$bin" --ignored --nocapture 2>&1 | tee "$log"; then
-              :
-            else
-              echo "TIMED_OUT_OR_FAILED (exit $?)" | tee -a "$log"
-            fi
+            local label=$1 test=$2 knob=$3 pooled=$4 obt=$5 log="/tmp/bench-$1.log" rc=0
+            echo "::group::$label ($knob=$pooled OPENBLAS_NUM_THREADS=${obt:-default})"
+            # Capture the pipeline's *left* exit status: without this the `tee`
+            # succeeds and a SIGKILLed timeout is silently recorded as a pass.
+            set +e
+            env "$knob=$pooled" ${obt:+OPENBLAS_NUM_THREADS=$obt} \
+              $TO "$bin" --exact "$test" --ignored --nocapture > "$log" 2>&1
+            rc=$?
+            set -e
+            cat "$log"
+            [ $rc -ne 0 ] && echo "TIMED_OUT_OR_FAILED rc=$rc" | tee -a "$log"
             echo "::endgroup::"
+            return 0
           }
 
-          run sliced        1 ""
-          run single        0 ""
-          run sliced-obt1   1 1
-          run single-obt1   0 1
+          C=conv_stem_gemm_bench
+          L=linear_gemm_bench
+          run conv-sliced      $C QASR_CONV_POOLED   1 ""
+          run conv-single      $C QASR_CONV_POOLED   0 ""
+          run conv-sliced-obt1 $C QASR_CONV_POOLED   1 1
+          run conv-single-obt1 $C QASR_CONV_POOLED   0 1
+          run lin-sliced       $L QASR_LINEAR_POOLED 1 ""
+          run lin-single       $L QASR_LINEAR_POOLED 0 ""
 
           total() {
             local v
             v=$(grep -h BENCH_TOTAL_MS "/tmp/bench-$1.log" 2>/dev/null | awk '{print $2}' | head -1)
-            echo "${v:-timeout/fail}"
+            if [ -z "$v" ]; then echo "**HANG/FAIL**"; else echo "$v ms"; fi
           }
           {
-            echo "### Conv-stem GEMM — ${{ matrix.os }} ($(uname -m), $(getconf _NPROCESSORS_ONLN) cores)"
+            echo "### GEMM pool-slicing — ${{ matrix.os }} ($(uname -m), $(getconf _NPROCESSORS_ONLN) cores)"
             echo ""
-            echo "| config | OpenBLAS threads | total |"
-            echo "|---|---|---|"
-            echo "| pool-sliced (Accelerate policy) | default | $(total sliced) ms |"
-            echo "| single BLAS call | default | $(total single) ms |"
-            echo "| pool-sliced | 1 | $(total sliced-obt1) ms |"
-            echo "| single BLAS call | 1 | $(total single-obt1) ms |"
+            echo "| path | sliced | OpenBLAS threads | total |"
+            echo "|---|---|---|---|"
+            echo "| conv stem | yes | default | $(total conv-sliced) |"
+            echo "| conv stem | no | default | $(total conv-single) |"
+            echo "| conv stem | yes | 1 | $(total conv-sliced-obt1) |"
+            echo "| conv stem | no | 1 | $(total conv-single-obt1) |"
+            echo "| linear | yes | default | $(total lin-sliced) |"
+            echo "| linear | no | default | $(total lin-single) |"
             echo ""
-            echo "A timeout in the pool-sliced rows is itself the result: issuing"
-            echo "concurrent \`cblas_sgemm\` calls from our pool is only safe on a"
-            echo "BLAS built for it, which is exactly what #47 gates off."
+            echo "A HANG in a sliced row is the result, not a flake: concurrent"
+            echo "\`cblas_sgemm\` entry is unsupported on stock OpenBLAS"
+            echo "(\`USE_LOCKING=1\` required), which is what #47 gates off."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/bench/blas_concurrency_repro.c
+++ b/bench/blas_concurrency_repro.c
@@ -1,0 +1,117 @@
+/* Does this machine's BLAS tolerate concurrent cblas_sgemm calls?
+ *
+ * Standalone: no model, no Rust, no qwen-asr source. It reproduces the two
+ * arrangements at the encoder conv-stem's real shape and times both.
+ *
+ *   A) ONE thread issues one sgemm(M=480, N=800, K=4320).
+ *      This is what antirez/qwen-asr does (qwen_asr_kernels.c, qwen_conv2d):
+ *      serial im2col, then a single full-width BLAS call. OpenBLAS threads it
+ *      internally.
+ *
+ *   B) 15 threads each issue sgemm(M=32, N=800, K=4320) over disjoint output
+ *      rows of the same C, sharing one B. This is what QwenASR did before
+ *      PR #51 -- and what stock OpenBLAS does not support: its thread server
+ *      needs USE_LOCKING=1 for concurrent entry.
+ *
+ * Build:
+ *   Linux:  gcc -O2 blas_concurrency_repro.c -o repro -lopenblas -lpthread
+ *   macOS:  clang -O2 blas_concurrency_repro.c -o repro -framework Accelerate
+ *
+ * Run:  ./repro
+ *
+ * If B hangs or is far slower than A, this machine's BLAS is not safe to call
+ * concurrently and PR #51's gating is the right fix. If B matches A, the BLAS
+ * is fine and QwenASR's slowness on this machine has another cause.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <pthread.h>
+
+#ifdef __APPLE__
+#include <Accelerate/Accelerate.h>
+#else
+#include <cblas.h>
+#endif
+
+/* Encoder conv layer 2 with enc_chunk_size=100, CONV_HIDDEN=480:
+ * C[480,800] = W[480,4320] @ cols[4320,800]. cols is ~13.2 MB and shared. */
+#define M_TOTAL 480
+#define N_DIM    800
+#define K_DIM   4320
+#define BLOCK     32                     /* output rows per slice */
+#define NSLICE  (M_TOTAL / BLOCK)        /* 15 concurrent BLAS calls */
+#define REPS      29                     /* chunks in a 28.2 s clip */
+
+static float *W, *B, *C;
+
+static double now_ms(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return ts.tv_sec * 1000.0 + ts.tv_nsec / 1e6;
+}
+
+static void fill(float *p, size_t n, unsigned s) {
+    for (size_t i = 0; i < n; i++) { s = s * 1103515245u + 12345u; p[i] = (float)((s >> 16) & 0xff) / 255.0f - 0.5f; }
+}
+
+/* One full-width call, exactly like antirez/qwen-asr's qwen_conv2d. */
+static void run_single(void) {
+    cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans,
+                M_TOTAL, N_DIM, K_DIM, 1.0f,
+                W, K_DIM, B, N_DIM, 0.0f, C, N_DIM);
+}
+
+static void *slice_worker(void *arg) {
+    long id = (long)arg;
+    int start = (int)id * BLOCK;
+    /* Disjoint output rows; every slice re-reads the whole shared B. */
+    cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans,
+                BLOCK, N_DIM, K_DIM, 1.0f,
+                W + (size_t)start * K_DIM, K_DIM, B, N_DIM,
+                0.0f, C + (size_t)start * N_DIM, N_DIM);
+    return NULL;
+}
+
+/* NSLICE threads inside BLAS at once, like QwenASR before PR #51. */
+static void run_sliced(void) {
+    pthread_t th[NSLICE];
+    for (long i = 0; i < NSLICE; i++) pthread_create(&th[i], NULL, slice_worker, (void *)i);
+    for (int i = 0; i < NSLICE; i++) pthread_join(th[i], NULL);
+}
+
+int main(void) {
+    W = malloc(sizeof(float) * (size_t)M_TOTAL * K_DIM);
+    B = malloc(sizeof(float) * (size_t)K_DIM * N_DIM);
+    C = malloc(sizeof(float) * (size_t)M_TOTAL * N_DIM);
+    if (!W || !B || !C) { fprintf(stderr, "alloc failed\n"); return 1; }
+    fill(W, (size_t)M_TOTAL * K_DIM, 1);
+    fill(B, (size_t)K_DIM * N_DIM, 2);
+
+    printf("shape C[%d,%d] = W[%d,%d] @ B[%d,%d], B = %.1f MB, %d reps\n",
+           M_TOTAL, N_DIM, M_TOTAL, K_DIM, K_DIM, N_DIM,
+           (double)K_DIM * N_DIM * 4 / (1024 * 1024), REPS);
+    printf("A = 1 thread, one full call   (antirez/qwen-asr)\n");
+    printf("B = %d threads, %d rows each   (QwenASR before #51)\n\n", NSLICE, BLOCK);
+
+    run_single();                       /* warm up */
+    double t0 = now_ms();
+    for (int i = 0; i < REPS; i++) run_single();
+    double single_ms = now_ms() - t0;
+    printf("A  single call : %8.1f ms\n", single_ms);
+    fflush(stdout);
+
+    printf("B  %2d threads  : ", NSLICE);
+    fflush(stdout);                     /* flush before the call that may hang */
+    t0 = now_ms();
+    for (int i = 0; i < REPS; i++) run_sliced();
+    double sliced_ms = now_ms() - t0;
+    printf("%8.1f ms\n\n", sliced_ms);
+
+    printf("ratio B/A = %.2fx %s\n", sliced_ms / single_ms,
+           sliced_ms > single_ms * 1.25 ? "  <-- concurrent entry is harmful here"
+                                        : "  (no penalty on this BLAS)");
+    free(W); free(B); free(C);
+    return 0;
+}

--- a/bench/blas_concurrency_repro.c
+++ b/bench/blas_concurrency_repro.c
@@ -11,10 +11,9 @@
  *   B) A pool of `nproc` workers (capped at 16, like kernels::get_default_threads)
  *      pulls 15 slices of sgemm(M=32, N=800, K=4320) off a shared counter, over
  *      disjoint output rows of the same C, sharing one B. This is what QwenASR
- *      did before PR #51 -- and what stock OpenBLAS does not support: its thread
- *      server needs USE_LOCKING=1 for concurrent entry. Concurrency is bounded
- *      by the pool, not by the slice count; one thread per slice would just
- *      oversubscribe a small box and measure the scheduler instead.
+ *      did before PR #51. Concurrency is bounded by the pool, not by the slice
+ *      count; one thread per slice would just oversubscribe a small box and
+ *      measure the scheduler instead.
  *
  * Build:
  *   Linux:  gcc -O2 blas_concurrency_repro.c -o repro -lopenblas -lpthread
@@ -22,9 +21,24 @@
  *
  * Run:  ./repro
  *
- * If B hangs or is far slower than A, this machine's BLAS is not safe to call
- * concurrently and PR #51's gating is the right fix. If B matches A, the BLAS
- * is fine and QwenASR's slowness on this machine has another cause.
+ * WHAT THIS DOES NOT SHOW. It was written to isolate the #47 hang outside our
+ * codebase, and it fails at that: on the very runner where the in-repo
+ * `gemm_pooling_bench` conv-sliced config hangs in 4 of 5 runs, config B here
+ * completes every time at a mild 1.24x. It also does not separate vendors --
+ * 1.24x on EPYC/OpenBLAS vs 1.40x on a 3-core M1 VM, while the real kernel
+ * hangs on one and gets *faster* on the other.
+ *
+ * The likely reason is that this uses plain pthread_create/join, whereas the
+ * real dispatch goes through a persistent pool whose join spins on an atomic
+ * with no yield (kernels/pool.rs). Concurrent BLAS entry may need that spinning
+ * to wedge. So treat "B is only mildly slower" here as NOT exonerating a BLAS.
+ *
+ * WHAT IT IS GOOD FOR: column A, one thread issuing one full-width sgemm, is a
+ * stable measure of how fast this BLAS is at the shape that dominates the
+ * encoder. Reference values, 29 reps: 69 ms on an M5 Pro, 107 ms on a 3-core
+ * M1 VM, 649 ms on a 4-core EPYC 7763 with libopenblas0-pthread 0.3.26. A
+ * machine far off those numbers has a slow BLAS build, independent of any
+ * concurrency question -- which is the open half of #47.
  */
 #include <stdio.h>
 #include <stdlib.h>
@@ -137,9 +151,11 @@ int main(void) {
     double sliced_ms = now_ms() - t0;
     printf("%8.1f ms\n\n", sliced_ms);
 
-    printf("ratio B/A = %.2fx %s\n", sliced_ms / single_ms,
-           sliced_ms > single_ms * 1.25 ? "  <-- concurrent entry is harmful here"
-                                        : "  (no penalty on this BLAS)");
+    /* Deliberately not labelled pass/fail: this ratio does not reliably
+     * separate a BLAS that wedges from one that does not. See the header. */
+    printf("ratio B/A = %.2fx\n", sliced_ms / single_ms);
+    printf("\nCompare column A against the reference values in the header;\n"
+           "the ratio is informational only and does not exonerate a BLAS.\n");
     free(W); free(B); free(C);
     return 0;
 }

--- a/bench/blas_concurrency_repro.c
+++ b/bench/blas_concurrency_repro.c
@@ -8,10 +8,13 @@
  *      serial im2col, then a single full-width BLAS call. OpenBLAS threads it
  *      internally.
  *
- *   B) 15 threads each issue sgemm(M=32, N=800, K=4320) over disjoint output
- *      rows of the same C, sharing one B. This is what QwenASR did before
- *      PR #51 -- and what stock OpenBLAS does not support: its thread server
- *      needs USE_LOCKING=1 for concurrent entry.
+ *   B) A pool of `nproc` workers (capped at 16, like kernels::get_default_threads)
+ *      pulls 15 slices of sgemm(M=32, N=800, K=4320) off a shared counter, over
+ *      disjoint output rows of the same C, sharing one B. This is what QwenASR
+ *      did before PR #51 -- and what stock OpenBLAS does not support: its thread
+ *      server needs USE_LOCKING=1 for concurrent entry. Concurrency is bounded
+ *      by the pool, not by the slice count; one thread per slice would just
+ *      oversubscribe a small box and measure the scheduler instead.
  *
  * Build:
  *   Linux:  gcc -O2 blas_concurrency_repro.c -o repro -lopenblas -lpthread
@@ -28,6 +31,7 @@
 #include <string.h>
 #include <time.h>
 #include <pthread.h>
+#include <unistd.h>
 
 #ifdef __APPLE__
 #include <Accelerate/Accelerate.h>
@@ -63,25 +67,48 @@ static void run_single(void) {
                 W, K_DIM, B, N_DIM, 0.0f, C, N_DIM);
 }
 
+/* Mirror QwenASR's `parallel_for_dynamic`: a fixed pool of `n_workers` threads
+ * pulls slice indices off a shared counter. Concurrency is bounded by the pool
+ * size, NOT by NSLICE -- spawning one thread per slice would oversubscribe a
+ * small machine 5:1 and measure scheduler thrash instead of BLAS reentrancy. */
+static int n_workers;
+static int next_slice;
+static pthread_mutex_t slice_lock = PTHREAD_MUTEX_INITIALIZER;
+
 static void *slice_worker(void *arg) {
-    long id = (long)arg;
-    int start = (int)id * BLOCK;
-    /* Disjoint output rows; every slice re-reads the whole shared B. */
-    cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans,
-                BLOCK, N_DIM, K_DIM, 1.0f,
-                W + (size_t)start * K_DIM, K_DIM, B, N_DIM,
-                0.0f, C + (size_t)start * N_DIM, N_DIM);
-    return NULL;
+    (void)arg;
+    for (;;) {
+        pthread_mutex_lock(&slice_lock);
+        int i = next_slice++;
+        pthread_mutex_unlock(&slice_lock);
+        if (i >= NSLICE) return NULL;
+        int start = i * BLOCK;
+        /* Disjoint output rows; every slice re-reads the whole shared B. */
+        cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans,
+                    BLOCK, N_DIM, K_DIM, 1.0f,
+                    W + (size_t)start * K_DIM, K_DIM, B, N_DIM,
+                    0.0f, C + (size_t)start * N_DIM, N_DIM);
+    }
 }
 
-/* NSLICE threads inside BLAS at once, like QwenASR before PR #51. */
+/* Up to n_workers threads inside BLAS at once, like QwenASR before PR #51. */
 static void run_sliced(void) {
     pthread_t th[NSLICE];
-    for (long i = 0; i < NSLICE; i++) pthread_create(&th[i], NULL, slice_worker, (void *)i);
-    for (int i = 0; i < NSLICE; i++) pthread_join(th[i], NULL);
+    next_slice = 0;
+    for (long i = 0; i < n_workers; i++) pthread_create(&th[i], NULL, slice_worker, (void *)i);
+    for (int i = 0; i < n_workers; i++) pthread_join(th[i], NULL);
 }
 
 int main(void) {
+    /* Match the pool QwenASR would use: online cores, capped at MAX_THREADS(16)
+     * like kernels::get_default_threads. Override with QASR_REPRO_THREADS. */
+    n_workers = (int)sysconf(_SC_NPROCESSORS_ONLN);
+    const char *env = getenv("QASR_REPRO_THREADS");
+    if (env && *env) n_workers = atoi(env);
+    if (n_workers < 1) n_workers = 1;
+    if (n_workers > 16) n_workers = 16;
+    if (n_workers > NSLICE) n_workers = NSLICE;
+
     W = malloc(sizeof(float) * (size_t)M_TOTAL * K_DIM);
     B = malloc(sizeof(float) * (size_t)K_DIM * N_DIM);
     C = malloc(sizeof(float) * (size_t)M_TOTAL * N_DIM);
@@ -92,8 +119,9 @@ int main(void) {
     printf("shape C[%d,%d] = W[%d,%d] @ B[%d,%d], B = %.1f MB, %d reps\n",
            M_TOTAL, N_DIM, M_TOTAL, K_DIM, K_DIM, N_DIM,
            (double)K_DIM * N_DIM * 4 / (1024 * 1024), REPS);
-    printf("A = 1 thread, one full call   (antirez/qwen-asr)\n");
-    printf("B = %d threads, %d rows each   (QwenASR before #51)\n\n", NSLICE, BLOCK);
+    printf("A = 1 thread, one full call         (antirez/qwen-asr)\n");
+    printf("B = %d workers over %d slices of %d rows  (QwenASR before #51)\n\n",
+           n_workers, NSLICE, BLOCK);
 
     run_single();                       /* warm up */
     double t0 = now_ms();
@@ -102,7 +130,7 @@ int main(void) {
     printf("A  single call : %8.1f ms\n", single_ms);
     fflush(stdout);
 
-    printf("B  %2d threads  : ", NSLICE);
+    printf("B  %2d workers  : ", n_workers);
     fflush(stdout);                     /* flush before the call that may hang */
     t0 = now_ms();
     for (int i = 0; i < REPS; i++) run_sliced();

--- a/crates/qwen-asr/src/kernels/mod.rs
+++ b/crates/qwen-asr/src/kernels/mod.rs
@@ -1178,6 +1178,66 @@ pub fn matmul_t(c: &mut [f32], a: &[f32], b: &[f32], m: usize, k: usize, n: usiz
     }
 }
 
+/// Whether to slice a BLAS GEMM across our own thread pool instead of issuing
+/// one call and letting the BLAS library thread it internally.
+///
+/// This is a *vendor* question, not an architecture question. Apple Accelerate
+/// runs a lone `sgemm` mostly on the calling thread, so slicing the output
+/// across the pool is what lets every core feed the matrix hardware (Round 10,
+/// measured ~30% end-to-end there). OpenBLAS is the opposite: it threads
+/// internally and packs the shared operand once per call. Slicing it hands
+/// every thread a full re-pack of the *same* matrix and divides the GEMM's
+/// arithmetic intensity by the slice count — see [`conv_pooled_gemm`] for the
+/// measured damage.
+///
+/// `default_on` is the built-in policy; the env var is an A/B override so a
+/// single binary can measure both sides on a machine we don't have.
+#[cfg(feature = "blas")]
+fn pooled_gemm_flag(var: &str, default_on: bool) -> bool {
+    std::env::var(var).map(|v| v != "0").unwrap_or(default_on)
+}
+
+/// Pool-slicing policy for the encoder's conv stem GEMMs. **Apple only.**
+///
+/// The conv stem is where slicing hurts most. With `enc_chunk_size = 100` and
+/// `CONV_HIDDEN = 480`, conv layer 2 is `C[480,800] = W[480,4320] @ cols[4320,800]`
+/// — a 13.8 MB shared `cols` operand. Slicing it into `480/32 = 15` blocks makes
+/// each block stream and re-pack all 13.8 MB to produce just 32 output rows,
+/// dropping arithmetic intensity from 480:1 to 32:1 and pushing the combined
+/// working set (~200 MB of packed panels) far past a desktop L3.
+///
+/// Measured on the same 28.2 s clip, same source, same call counts (issue #47):
+/// `conv2d_op` is 60 ms on an M5 Pro and 12659 ms on a Ryzen 9 5900X — 211x,
+/// against a ~8x hardware baseline set by the purely bandwidth-bound
+/// `bf16_matvec` (170 ms vs 1399 ms). That is ~25x beyond what the memory
+/// system alone explains, and it accounts for 95% of the encoder's time there.
+///
+/// Off by default on non-Apple BLAS so OpenBLAS packs once and blocks the GEMM
+/// itself. Override with `QASR_CONV_POOLED=1`/`0`.
+#[cfg(feature = "blas")]
+pub(crate) fn conv_pooled_gemm() -> bool {
+    use std::sync::OnceLock;
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        pooled_gemm_flag("QASR_CONV_POOLED", cfg!(target_vendor = "apple"))
+    })
+}
+
+/// Pool-slicing policy for the `linear` / attention-projection GEMMs.
+///
+/// Left **on everywhere** for now: unlike the conv stem, `sgemm` measured 8.3x
+/// on the 5900X (233 ms vs 1940 ms), which sits at the hardware baseline rather
+/// than above it, so there is no evidence it is hurting. The same re-pack
+/// mechanism applies in principle — the operands are much smaller and the slice
+/// count lower (`out_dim = 896` → 7 slices) — so it is exposed as a separate
+/// knob to measure independently. Override with `QASR_LINEAR_POOLED=0`.
+#[cfg(feature = "blas")]
+pub(crate) fn linear_pooled_gemm() -> bool {
+    use std::sync::OnceLock;
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| pooled_gemm_flag("QASR_LINEAR_POOLED", true))
+}
+
 /// Pool-parallel `y[seq,out] = x @ W^T + beta*y (+ b)`: splits the output
 /// columns across the persistent thread pool, one BLAS call per slice. Each
 /// output element is still a single full-K dot product inside one sgemm call.
@@ -1202,7 +1262,12 @@ fn sgemm_nt_pooled(
     // whole product enough MACs to amortize the pool dispatch.
     const MIN_COLS: usize = 128;
     const MIN_MACS: usize = 1 << 22;
-    if nt <= 1 || seq_len < 2 || out_dim < 2 * MIN_COLS || seq_len * in_dim * out_dim < MIN_MACS {
+    if !linear_pooled_gemm()
+        || nt <= 1
+        || seq_len < 2
+        || out_dim < 2 * MIN_COLS
+        || seq_len * in_dim * out_dim < MIN_MACS
+    {
         return false;
     }
     let y_send = y.as_mut_ptr() as usize;
@@ -2142,12 +2207,18 @@ fn conv2d_impl(
     }
 
     // GEMM: weight[c_out, patch_size] @ cols[patch_size, spatial_out] = out[c_out, spatial_out]
-    // Split output channels across the pool (one sgemm slice per thread) so
-    // the workers that just finished im2col also share the GEMM instead of
-    // idling behind a single main-thread BLAS call.
+    // On Accelerate, split output channels across the pool (one sgemm slice per
+    // thread) so the workers that just finished im2col also share the GEMM
+    // instead of idling behind a single main-thread BLAS call. On a BLAS that
+    // threads internally this is a large *pessimization* — every slice re-packs
+    // the whole shared `cols` operand — so `conv_pooled_gemm` gates it off and
+    // the single call below lets the library block the GEMM itself.
     #[cfg(feature = "blas")]
     unsafe {
-        if n_threads > 1 && c_out >= 2 * n_threads && c_out * patch_size * spatial_out >= (1 << 22)
+        if conv_pooled_gemm()
+            && n_threads > 1
+            && c_out >= 2 * n_threads
+            && c_out * patch_size * spatial_out >= (1 << 22)
         {
             let out_send = out.as_mut_ptr() as usize;
             let w_send = weight.as_ptr() as usize;

--- a/crates/qwen-asr/src/kernels/mod.rs
+++ b/crates/qwen-asr/src/kernels/mod.rs
@@ -1218,9 +1218,7 @@ fn pooled_gemm_flag(var: &str, default_on: bool) -> bool {
 pub(crate) fn conv_pooled_gemm() -> bool {
     use std::sync::OnceLock;
     static ENABLED: OnceLock<bool> = OnceLock::new();
-    *ENABLED.get_or_init(|| {
-        pooled_gemm_flag("QASR_CONV_POOLED", cfg!(target_vendor = "apple"))
-    })
+    *ENABLED.get_or_init(|| pooled_gemm_flag("QASR_CONV_POOLED", cfg!(target_vendor = "apple")))
 }
 
 /// Pool-slicing policy for the `linear` / attention-projection GEMMs.

--- a/crates/qwen-asr/src/kernels/mod.rs
+++ b/crates/qwen-asr/src/kernels/mod.rs
@@ -1181,14 +1181,32 @@ pub fn matmul_t(c: &mut [f32], a: &[f32], b: &[f32], m: usize, k: usize, n: usiz
 /// Whether to slice a BLAS GEMM across our own thread pool instead of issuing
 /// one call and letting the BLAS library thread it internally.
 ///
-/// This is a *vendor* question, not an architecture question. Apple Accelerate
-/// runs a lone `sgemm` mostly on the calling thread, so slicing the output
-/// across the pool is what lets every core feed the matrix hardware (Round 10,
-/// measured ~30% end-to-end there). OpenBLAS is the opposite: it threads
-/// internally and packs the shared operand once per call. Slicing it hands
-/// every thread a full re-pack of the *same* matrix and divides the GEMM's
-/// arithmetic intensity by the slice count — see [`conv_pooled_gemm`] for the
-/// measured damage.
+/// This is a *vendor* question, not an architecture question, and it is a
+/// **soundness** question before it is a performance one.
+///
+/// Slicing means N pool threads each call `cblas_sgemm` concurrently. That is
+/// only legal on a BLAS built to be called from multiple threads: stock
+/// OpenBLAS documents its thread server as requiring `USE_LOCKING=1` for
+/// concurrent entry, and Ubuntu's `libopenblas0-pthread` 0.3.26 is not built
+/// that way. Apple Accelerate is safe here, and slicing is a real win there
+/// because a lone `sgemm` runs mostly on the calling thread, leaving the pool
+/// idle (Round 10, ~30% end-to-end).
+///
+/// Measured on an AMD EPYC 7763 (Zen 3, 4 cores) with that OpenBLAS, on the
+/// encoder stem's real shapes (`conv-stem-bench` in CI):
+///
+/// | slicing | `OPENBLAS_NUM_THREADS` | conv stem |
+/// |---|---|---|
+/// | on  | default | **hangs — killed at 300 s** |
+/// | off | default | 951.9 ms |
+/// | on  | 1       | 946.6 ms |
+/// | off | 1       | 1450.7 ms |
+///
+/// The first two rows are the finding: the same sliced code completes in
+/// 946.6 ms once OpenBLAS's own threading is disabled, so the hang is the
+/// concurrent-entry problem and not the workload. Rows 2 and 3 are within noise
+/// of each other, so slicing buys nothing here even when it does complete —
+/// there is one unit of parallelism available and either layer can supply it.
 ///
 /// `default_on` is the built-in policy; the env var is an A/B override so a
 /// single binary can measure both sides on a machine we don't have.
@@ -1199,21 +1217,10 @@ fn pooled_gemm_flag(var: &str, default_on: bool) -> bool {
 
 /// Pool-slicing policy for the encoder's conv stem GEMMs. **Apple only.**
 ///
-/// The conv stem is where slicing hurts most. With `enc_chunk_size = 100` and
-/// `CONV_HIDDEN = 480`, conv layer 2 is `C[480,800] = W[480,4320] @ cols[4320,800]`
-/// — a 13.8 MB shared `cols` operand. Slicing it into `480/32 = 15` blocks makes
-/// each block stream and re-pack all 13.8 MB to produce just 32 output rows,
-/// dropping arithmetic intensity from 480:1 to 32:1 and pushing the combined
-/// working set (~200 MB of packed panels) far past a desktop L3.
-///
-/// Measured on the same 28.2 s clip, same source, same call counts (issue #47):
-/// `conv2d_op` is 60 ms on an M5 Pro and 12659 ms on a Ryzen 9 5900X — 211x,
-/// against a ~8x hardware baseline set by the purely bandwidth-bound
-/// `bf16_matvec` (170 ms vs 1399 ms). That is ~25x beyond what the memory
-/// system alone explains, and it accounts for 95% of the encoder's time there.
-///
-/// Off by default on non-Apple BLAS so OpenBLAS packs once and blocks the GEMM
-/// itself. Override with `QASR_CONV_POOLED=1`/`0`.
+/// This is the path that hangs on stock OpenBLAS — see [`pooled_gemm_flag`] for
+/// the measurements. It issues the most concurrent `cblas_sgemm` calls of any
+/// path in the encoder: 87 conv invocations per 28 s clip, each sliced into
+/// `480/32 = 15` blocks. Override with `QASR_CONV_POOLED=1`/`0`.
 #[cfg(feature = "blas")]
 pub(crate) fn conv_pooled_gemm() -> bool {
     use std::sync::OnceLock;
@@ -1222,18 +1229,20 @@ pub(crate) fn conv_pooled_gemm() -> bool {
 }
 
 /// Pool-slicing policy for the `linear` / attention-projection GEMMs.
+/// **Apple only**, for the same reason as [`conv_pooled_gemm`].
 ///
-/// Left **on everywhere** for now: unlike the conv stem, `sgemm` measured 8.3x
-/// on the 5900X (233 ms vs 1940 ms), which sits at the hardware baseline rather
-/// than above it, so there is no evidence it is hurting. The same re-pack
-/// mechanism applies in principle — the operands are much smaller and the slice
-/// count lower (`out_dim = 896` → 7 slices) — so it is exposed as a separate
-/// knob to measure independently. Override with `QASR_LINEAR_POOLED=0`.
+/// This path was initially left on everywhere because `sgemm` measured 8.3x on
+/// the 5900X — at the hardware baseline, so no evidence it was *slow*. That
+/// reasoning does not survive the conv-stem result: the concern is not speed
+/// but that concurrent `cblas_sgemm` entry is unsupported on stock OpenBLAS
+/// regardless of which call site does it. Fewer slices (`out_dim = 896` → 7)
+/// and smaller operands presumably make a hang less likely, not impossible.
+/// Override with `QASR_LINEAR_POOLED=1`/`0`.
 #[cfg(feature = "blas")]
 pub(crate) fn linear_pooled_gemm() -> bool {
     use std::sync::OnceLock;
     static ENABLED: OnceLock<bool> = OnceLock::new();
-    *ENABLED.get_or_init(|| pooled_gemm_flag("QASR_LINEAR_POOLED", true))
+    *ENABLED.get_or_init(|| pooled_gemm_flag("QASR_LINEAR_POOLED", cfg!(target_vendor = "apple")))
 }
 
 /// Pool-parallel `y[seq,out] = x @ W^T + beta*y (+ b)`: splits the output

--- a/crates/qwen-asr/src/kernels/mod.rs
+++ b/crates/qwen-asr/src/kernels/mod.rs
@@ -1228,6 +1228,35 @@ pub(crate) fn conv_pooled_gemm() -> bool {
     *ENABLED.get_or_init(|| pooled_gemm_flag("QASR_CONV_POOLED", cfg!(target_vendor = "apple")))
 }
 
+/// Pool-parallel head split for **multi-token** attention. **Apple only.**
+///
+/// Third site with the same shape as the other two, found by auditing every
+/// `cblas_sgemm` call against its callers. [`causal_attention`] fans out over
+/// query heads with `parallel_for`; for `seq_q > 1` each worker issues two
+/// `cblas_sgemm` calls per head, so prefill puts up to `n_heads` threads in
+/// BLAS at once.
+///
+/// Measured on the prefill shapes (16/8 heads, head_dim 64, seq 512, 28 layers):
+/// splitting heads is **1.55x slower** on the EPYC/OpenBLAS runner (909.3 vs
+/// 586.2 ms) and **3.0x faster** on an M5 Pro (48.7 vs 144.6 ms). A clean vendor
+/// split, so it is gated rather than removed. Override with `QASR_ATTN_POOLED`.
+///
+/// Only consulted for `seq_q > 1`: single-token decode takes the BLAS-free
+/// online-softmax scan, where head parallelism is safe and valuable everywhere.
+#[cfg(feature = "blas")]
+pub(crate) fn attn_parallel_heads() -> bool {
+    use std::sync::OnceLock;
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| pooled_gemm_flag("QASR_ATTN_POOLED", cfg!(target_vendor = "apple")))
+}
+
+/// No BLAS in this build, so `causal_attention_heads` runs the online-softmax
+/// scan for every `seq_q` and there is no concurrent-entry hazard to avoid.
+#[cfg(not(feature = "blas"))]
+pub(crate) fn attn_parallel_heads() -> bool {
+    true
+}
+
 /// Pool-slicing policy for the `linear` / attention-projection GEMMs.
 /// **Apple only**, for the same reason as [`conv_pooled_gemm`].
 ///
@@ -3079,7 +3108,12 @@ pub fn causal_attention(
 ) {
     let _pg = ProfileGuard::new(&PROF.attention_causal);
     let n_threads = get_num_threads();
-    if n_threads > 1 && n_heads >= 2 {
+    // `seq_q == 1` takes the BLAS-free online-softmax branch inside
+    // `causal_attention_heads`, so splitting heads across the pool is safe on
+    // every platform. `seq_q > 1` issues two `cblas_sgemm` per head, and fanning
+    // that out means N threads inside BLAS at once — see `attn_parallel_heads`.
+    let par_heads = seq_q == 1 || attn_parallel_heads();
+    if n_threads > 1 && n_heads >= 2 && par_heads {
         let out_ptr = out.as_mut_ptr() as usize;
         let q_ptr = q.as_ptr() as usize;
         let k_ptr = k_base as usize;

--- a/crates/qwen-asr/src/lib.rs
+++ b/crates/qwen-asr/src/lib.rs
@@ -76,10 +76,14 @@ pub mod transcribe;
 pub fn optimization_flags() -> Vec<&'static str> {
     let mut flags = Vec::new();
 
-    if cfg!(feature = "vdsp") {
+    // The `vdsp` feature only reaches real code on Apple platforms; reporting
+    // "vDSP/Accelerate" on a Linux build (where `blas` means OpenBLAS) sent
+    // issue #47 chasing the wrong library.
+    let apple_vdsp = cfg!(feature = "vdsp") && cfg!(target_vendor = "apple");
+    if apple_vdsp {
         flags.push("vDSP/Accelerate");
     }
-    if cfg!(feature = "blas") && !cfg!(feature = "vdsp") {
+    if cfg!(feature = "blas") && !apple_vdsp {
         flags.push("BLAS");
     }
 

--- a/crates/qwen-asr/tests/conv_stem_bench.rs
+++ b/crates/qwen-asr/tests/conv_stem_bench.rs
@@ -1,0 +1,173 @@
+//! Conv-stem GEMM microbenchmark for issue #47.
+//!
+//! Reproduces the encoder stem's three `conv2d_with_cols` calls at their real
+//! shapes without needing the model: only the shapes and the BLAS call pattern
+//! matter for the effect under test, so random weights are fine.
+//!
+//! The pool-slicing policy (`QASR_CONV_POOLED`) is cached in a `OnceLock`, so a
+//! single process can only measure one side. CI runs this binary twice, once
+//! per setting, and diffs the printed totals — see `.github/workflows/ci.yml`.
+//!
+//! `#[ignore]`d so it never runs as part of the normal suite.
+
+use qwen_asr::config::CONV_HIDDEN;
+use qwen_asr::kernels;
+use std::time::Instant;
+
+/// Mel bins in, and the encoder's `enc_chunk_size` (see `config.rs`). A 28.2 s
+/// clip is 2820 mel frames, so 29 chunks — the 87 `conv2d_op` calls in the
+/// issue's profile output.
+const MEL_BINS: usize = 128;
+const CHUNK_W: usize = 100;
+const N_CHUNKS: usize = 29;
+
+/// Deterministic filler. Values only need to be finite and non-degenerate;
+/// a plain LCG keeps this dependency-free and reproducible across runs.
+fn fill_pseudo_random(buf: &mut [f32], seed: u64) {
+    let mut s = seed | 1;
+    for v in buf.iter_mut() {
+        s = s
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        // Map the high bits into roughly [-0.5, 0.5].
+        *v = ((s >> 33) as f32 / (1u64 << 31) as f32) - 0.5;
+    }
+}
+
+struct Layer {
+    name: &'static str,
+    c_in: usize,
+    c_out: usize,
+    h_in: usize,
+    w_in: usize,
+}
+
+impl Layer {
+    fn out_dims(&self) -> (usize, usize) {
+        // kernel 3, stride 2, padding 1 for all three stem convs.
+        ((self.h_in + 2 - 3) / 2 + 1, (self.w_in + 2 - 3) / 2 + 1)
+    }
+}
+
+#[test]
+#[ignore = "microbenchmark; run explicitly with --ignored --nocapture"]
+fn conv_stem_gemm_bench() {
+    let threads = kernels::get_default_threads();
+    kernels::set_threads(threads);
+
+    // The stem's three convs, chained: each layer's output dims feed the next.
+    let (h1, w1) = ((MEL_BINS + 2 - 3) / 2 + 1, (CHUNK_W + 2 - 3) / 2 + 1);
+    let (h2, w2) = ((h1 + 2 - 3) / 2 + 1, (w1 + 2 - 3) / 2 + 1);
+    let layers = [
+        Layer {
+            name: "conv1",
+            c_in: 1,
+            c_out: CONV_HIDDEN,
+            h_in: MEL_BINS,
+            w_in: CHUNK_W,
+        },
+        Layer {
+            name: "conv2",
+            c_in: CONV_HIDDEN,
+            c_out: CONV_HIDDEN,
+            h_in: h1,
+            w_in: w1,
+        },
+        Layer {
+            name: "conv3",
+            c_in: CONV_HIDDEN,
+            c_out: CONV_HIDDEN,
+            h_in: h2,
+            w_in: w2,
+        },
+    ];
+
+    let pooled = std::env::var("QASR_CONV_POOLED").unwrap_or_else(|_| "<default>".into());
+    println!("threads={threads} QASR_CONV_POOLED={pooled} chunks={N_CHUNKS}");
+
+    let mut grand_total_ms = 0.0f64;
+    let mut grand_total_macs = 0u64;
+
+    for layer in &layers {
+        let (h_out, w_out) = layer.out_dims();
+        let patch = layer.c_in * 3 * 3;
+        let spatial = h_out * w_out;
+
+        let mut input = vec![0.0f32; layer.c_in * layer.h_in * layer.w_in];
+        let mut weight = vec![0.0f32; layer.c_out * patch];
+        let bias = vec![0.0f32; layer.c_out];
+        fill_pseudo_random(&mut input, 0x5EED);
+        fill_pseudo_random(&mut weight, 0xC0FFEE);
+
+        let mut out = vec![0.0f32; layer.c_out * spatial];
+        let mut cols: Vec<f32> = Vec::new();
+
+        // One untimed pass so the `cols` scratch is grown and pages are faulted
+        // in; the real encoder reuses these buffers across chunks.
+        kernels::conv2d_with_cols(
+            &mut out,
+            &input,
+            &weight,
+            Some(&bias),
+            &mut cols,
+            layer.c_in,
+            layer.c_out,
+            layer.h_in,
+            layer.w_in,
+            3,
+            3,
+            2,
+            1,
+        );
+
+        let start = Instant::now();
+        for _ in 0..N_CHUNKS {
+            kernels::conv2d_with_cols(
+                &mut out,
+                &input,
+                &weight,
+                Some(&bias),
+                &mut cols,
+                layer.c_in,
+                layer.c_out,
+                layer.h_in,
+                layer.w_in,
+                3,
+                3,
+                2,
+                1,
+            );
+        }
+        let ms = start.elapsed().as_secs_f64() * 1000.0;
+
+        let macs = (layer.c_out * patch * spatial) as u64 * N_CHUNKS as u64;
+        grand_total_ms += ms;
+        grand_total_macs += macs;
+
+        println!(
+            "{:<6} M={:<4} N={:<5} K={:<5} cols={:>6.1}MB  {:>9.1} ms  ({:>6.1} GFLOP/s)",
+            layer.name,
+            layer.c_out,
+            spatial,
+            patch,
+            (patch * spatial * 4) as f64 / (1024.0 * 1024.0),
+            ms,
+            (2.0 * macs as f64) / (ms / 1000.0) / 1e9,
+        );
+
+        // Guard against the compiler deciding none of this is observable.
+        assert!(
+            out.iter().all(|v| v.is_finite()),
+            "{} produced non-finite output",
+            layer.name
+        );
+    }
+
+    println!(
+        "TOTAL  {:.1} ms  ({:.1} GFLOP/s)",
+        grand_total_ms,
+        (2.0 * grand_total_macs as f64) / (grand_total_ms / 1000.0) / 1e9,
+    );
+    // Machine-readable line for the CI comparison step.
+    println!("BENCH_TOTAL_MS {grand_total_ms:.1}");
+}

--- a/crates/qwen-asr/tests/conv_stem_bench.rs
+++ b/crates/qwen-asr/tests/conv_stem_bench.rs
@@ -171,3 +171,66 @@ fn conv_stem_gemm_bench() {
     // Machine-readable line for the CI comparison step.
     println!("BENCH_TOTAL_MS {grand_total_ms:.1}");
 }
+
+/// The other site that issues concurrent `cblas_sgemm` calls from the pool:
+/// `linear`, via `sgemm_nt_pooled`. The conv stem hangs on stock OpenBLAS when
+/// sliced; this covers whether `linear`'s smaller operands and lower slice
+/// count (`out_dim = 896` → 7) avoid it or merely make it rarer. Driven by
+/// `QASR_LINEAR_POOLED`.
+#[test]
+#[ignore = "microbenchmark; run explicitly with --ignored --nocapture"]
+fn linear_gemm_bench() {
+    let threads = kernels::get_default_threads();
+    kernels::set_threads(threads);
+
+    // Encoder transformer shapes: d_model 896, ffn 3584, ~750 tokens for a
+    // 28 s clip. `sgemm_nt_pooled` needs seq_len >= 2 and out_dim >= 256.
+    const SEQ: usize = 750;
+    const D: usize = 896;
+    const FFN: usize = 3584;
+    let shapes = [("qkvo", D, D), ("fc1", D, FFN), ("fc2", FFN, D)];
+
+    let pooled = std::env::var("QASR_LINEAR_POOLED").unwrap_or_else(|_| "<default>".into());
+    println!("threads={threads} QASR_LINEAR_POOLED={pooled} seq={SEQ}");
+
+    let mut total_ms = 0.0f64;
+    let mut total_macs = 0u64;
+    // 18 encoder layers; one representative call per shape per layer.
+    const REPS: usize = 18;
+
+    for (name, in_dim, out_dim) in shapes {
+        let mut x = vec![0.0f32; SEQ * in_dim];
+        let mut w = vec![0.0f32; out_dim * in_dim];
+        let b = vec![0.0f32; out_dim];
+        fill_pseudo_random(&mut x, 0xA11CE);
+        fill_pseudo_random(&mut w, 0xB0B);
+        let mut y = vec![0.0f32; SEQ * out_dim];
+
+        kernels::linear(&mut y, &x, &w, Some(&b), SEQ, in_dim, out_dim);
+
+        let start = Instant::now();
+        for _ in 0..REPS {
+            kernels::linear(&mut y, &x, &w, Some(&b), SEQ, in_dim, out_dim);
+        }
+        let ms = start.elapsed().as_secs_f64() * 1000.0;
+
+        let macs = (SEQ * in_dim * out_dim) as u64 * REPS as u64;
+        total_ms += ms;
+        total_macs += macs;
+        println!(
+            "{name:<5} M={SEQ:<4} N={out_dim:<5} K={in_dim:<5} {ms:>9.1} ms  ({:>6.1} GFLOP/s)",
+            (2.0 * macs as f64) / (ms / 1000.0) / 1e9,
+        );
+        assert!(
+            y.iter().all(|v| v.is_finite()),
+            "{name} produced non-finite output"
+        );
+    }
+
+    println!(
+        "TOTAL  {:.1} ms  ({:.1} GFLOP/s)",
+        total_ms,
+        (2.0 * total_macs as f64) / (total_ms / 1000.0) / 1e9,
+    );
+    println!("BENCH_TOTAL_MS {total_ms:.1}");
+}

--- a/crates/qwen-asr/tests/gemm_pooling_bench.rs
+++ b/crates/qwen-asr/tests/gemm_pooling_bench.rs
@@ -5,8 +5,8 @@
 //!
 //! 1. [`conv_stem_gemm_bench`] — the encoder conv stem (`QASR_CONV_POOLED`).
 //! 2. [`linear_gemm_bench`] — `linear` via `sgemm_nt_pooled` (`QASR_LINEAR_POOLED`).
-//! 3. [`causal_attention_prefill_bench`] — head-parallel prefill attention.
-//!    **Not gated by anything yet**; this measures whether it needs to be.
+//! 3. [`causal_attention_prefill_bench`] — head-parallel prefill attention
+//!    (`QASR_ATTN_POOLED`).
 //!
 //! Each reproduces its kernel's real shapes without the model: only the shapes
 //! and the BLAS call pattern drive the effect, so random weights are fine.
@@ -249,8 +249,8 @@ fn linear_gemm_bench() {
 /// decoder prefill path (`decoder.rs:926` passes `seq_len`, not 1); single-token
 /// decode takes the BLAS-free online-softmax branch and is unaffected.
 ///
-/// There is no knob for this one yet — that is the point of measuring it. Run it
-/// with `QASR_ATTN_THREADS=1` to get the serial reference.
+/// Gated by `attn_parallel_heads` (Apple-only default); `QASR_ATTN_POOLED=1`
+/// forces the fan-out on so the off-vendor cost stays visible in CI.
 #[test]
 #[ignore = "microbenchmark; run explicitly with --ignored --nocapture"]
 fn causal_attention_prefill_bench() {
@@ -262,15 +262,13 @@ fn causal_attention_prefill_bench() {
     const LAYERS: usize = 28;
     const SEQ: usize = 512;
 
-    // Empty must mean "default", not "unparseable → 1": CI passes the knob as
-    // `QASR_ATTN_THREADS=` for the parallel config, and silently falling back to
-    // 1 there would make the parallel and serial rows identical.
-    let threads = match std::env::var("QASR_ATTN_THREADS") {
-        Ok(v) if !v.trim().is_empty() => v.trim().parse().unwrap_or(1),
-        _ => kernels::get_default_threads(),
-    };
+    // Drive the real `attn_parallel_heads` gate rather than a thread-count
+    // proxy, so this measures the shipped decision. The pool keeps all its
+    // threads either way; only the head fan-out changes.
+    let threads = kernels::get_default_threads();
     kernels::set_threads(threads);
-    println!("threads={threads} seq_q={SEQ} seq_k={SEQ} heads={N_HEADS}/{N_KV}");
+    let pooled = std::env::var("QASR_ATTN_POOLED").unwrap_or_else(|_| "<default>".into());
+    println!("threads={threads} QASR_ATTN_POOLED={pooled} seq_q={SEQ} seq_k={SEQ} heads={N_HEADS}/{N_KV}");
 
     let q_hidden = N_HEADS * HEAD_DIM;
     // KV cache layout is [head][pos][head_dim]; head_stride spans one KV head.

--- a/crates/qwen-asr/tests/gemm_pooling_bench.rs
+++ b/crates/qwen-asr/tests/gemm_pooling_bench.rs
@@ -1,14 +1,21 @@
-//! Conv-stem GEMM microbenchmark for issue #47.
+//! Microbenchmarks for issue #47: every site where N pool threads call
+//! `cblas_sgemm` concurrently.
 //!
-//! Reproduces the encoder stem's three `conv2d_with_cols` calls at their real
-//! shapes without needing the model: only the shapes and the BLAS call pattern
-//! matter for the effect under test, so random weights are fine.
+//! There are three, and they are covered here in the order they were found:
 //!
-//! The pool-slicing policy (`QASR_CONV_POOLED`) is cached in a `OnceLock`, so a
-//! single process can only measure one side. CI runs this binary twice, once
-//! per setting, and diffs the printed totals — see `.github/workflows/ci.yml`.
+//! 1. [`conv_stem_gemm_bench`] — the encoder conv stem (`QASR_CONV_POOLED`).
+//! 2. [`linear_gemm_bench`] — `linear` via `sgemm_nt_pooled` (`QASR_LINEAR_POOLED`).
+//! 3. [`causal_attention_prefill_bench`] — head-parallel prefill attention.
+//!    **Not gated by anything yet**; this measures whether it needs to be.
 //!
-//! `#[ignore]`d so it never runs as part of the normal suite.
+//! Each reproduces its kernel's real shapes without the model: only the shapes
+//! and the BLAS call pattern drive the effect, so random weights are fine.
+//!
+//! The policy flags are cached in a `OnceLock`, so one process can only measure
+//! one side. CI runs this binary once per configuration and diffs the printed
+//! `BENCH_TOTAL_MS` lines — see `.github/workflows/ci.yml`.
+//!
+//! `#[ignore]`d so they never run as part of the normal suite.
 
 use qwen_asr::config::CONV_HIDDEN;
 use qwen_asr::kernels;
@@ -233,4 +240,81 @@ fn linear_gemm_bench() {
         (2.0 * total_macs as f64) / (total_ms / 1000.0) / 1e9,
     );
     println!("BENCH_TOTAL_MS {total_ms:.1}");
+}
+
+/// The third site that issues concurrent `cblas_sgemm` calls from the pool, and
+/// the one #47's gating does *not* cover: `causal_attention` fans out over
+/// query heads with `parallel_for`, and for `seq_q > 1` each worker's
+/// `causal_attention_heads` issues two `cblas_sgemm` calls per head. That is the
+/// decoder prefill path (`decoder.rs:926` passes `seq_len`, not 1); single-token
+/// decode takes the BLAS-free online-softmax branch and is unaffected.
+///
+/// There is no knob for this one yet — that is the point of measuring it. Run it
+/// with `QASR_ATTN_THREADS=1` to get the serial reference.
+#[test]
+#[ignore = "microbenchmark; run explicitly with --ignored --nocapture"]
+fn causal_attention_prefill_bench() {
+    // Decoder geometry: 16 query heads, 8 KV heads (GQA), head_dim 64, 28
+    // layers. seq_q = seq_k = a representative prefill length.
+    const N_HEADS: usize = 16;
+    const N_KV: usize = 8;
+    const HEAD_DIM: usize = 64;
+    const LAYERS: usize = 28;
+    const SEQ: usize = 512;
+
+    // Empty must mean "default", not "unparseable → 1": CI passes the knob as
+    // `QASR_ATTN_THREADS=` for the parallel config, and silently falling back to
+    // 1 there would make the parallel and serial rows identical.
+    let threads = match std::env::var("QASR_ATTN_THREADS") {
+        Ok(v) if !v.trim().is_empty() => v.trim().parse().unwrap_or(1),
+        _ => kernels::get_default_threads(),
+    };
+    kernels::set_threads(threads);
+    println!("threads={threads} seq_q={SEQ} seq_k={SEQ} heads={N_HEADS}/{N_KV}");
+
+    let q_hidden = N_HEADS * HEAD_DIM;
+    // KV cache layout is [head][pos][head_dim]; head_stride spans one KV head.
+    let head_stride = SEQ * HEAD_DIM;
+    let mut q = vec![0.0f32; SEQ * q_hidden];
+    let mut k = vec![0.0f32; N_KV * head_stride];
+    let mut v = vec![0.0f32; N_KV * head_stride];
+    fill_pseudo_random(&mut q, 0xDEC0DE);
+    fill_pseudo_random(&mut k, 0x1234_5678);
+    fill_pseudo_random(&mut v, 0x8765_4321);
+    let mut out = vec![0.0f32; SEQ * q_hidden];
+    let scale = 1.0 / (HEAD_DIM as f32).sqrt();
+
+    let call = |out: &mut Vec<f32>| {
+        kernels::causal_attention(
+            out,
+            &q,
+            k.as_ptr(),
+            v.as_ptr(),
+            head_stride,
+            SEQ,
+            SEQ,
+            N_HEADS,
+            N_KV,
+            HEAD_DIM,
+            scale,
+            0,
+        );
+    };
+    call(&mut out);
+
+    let start = Instant::now();
+    for _ in 0..LAYERS {
+        call(&mut out);
+    }
+    let ms = start.elapsed().as_secs_f64() * 1000.0;
+
+    assert!(
+        out.iter().all(|x| x.is_finite()),
+        "non-finite attention output"
+    );
+    println!(
+        "attn   {LAYERS} layers  {ms:.1} ms  ({:.2} ms/layer)",
+        ms / LAYERS as f64
+    );
+    println!("BENCH_TOTAL_MS {ms:.1}");
 }


### PR DESCRIPTION
Draft. Refs #47.

Three kernels had N pool threads each calling `cblas_sgemm` concurrently. That is safe and valuable on Apple Accelerate; on stock OpenBLAS it hangs. This gates all three to Apple.

> **Two corrections to earlier revisions of this PR**, kept visible because both were wrong in ways the measurements caught:
> 1. It first blamed redundant operand re-packing dividing arithmetic intensity. Refuted — slicing is throughput-neutral in isolation.
> 2. It then claimed slicing "costs nothing in throughput when it completes." Over-read from a run where that config *hung* and so produced no number. It costs 1.4–2.6×.

## The defect

Slicing means N pool threads call `cblas_sgemm` at the same time. Empirically that is fine on Apple Accelerate and breaks on stock OpenBLAS. Three sites, found by auditing every `cblas_sgemm` call against its callers:

| # | site | reached from |
|---|---|---|
| 1 | `conv2d_impl` pooled branch | encoder conv stem |
| 2 | `sgemm_nt_pooled` (`linear`, `linear_accumulate`) | encoder projections + FFN |
| 3 | `causal_attention` → `causal_attention_heads`, `seq_q > 1` | decoder prefill (`decoder.rs:926`) |

Site 3 was missed by the first version of this PR. `attn_head_range` only groups by KV head when `seq_q == 1`; above that it splits by query head across every worker, and each worker then issues two `cblas_sgemm` per head.

**The exact mechanism is not pinned down**, and I want to be clear about that rather than assert a tidy story a fourth time. The obvious candidate is OpenBLAS's thread server needing `USE_LOCKING=1` for concurrent entry, but `bench/blas_concurrency_repro.c` — which does exactly that concurrent entry, standalone, at the same shape — **does not reproduce the hang** on the runner where the real kernel hangs in 4 of 5 runs. Something the repro lacks is required to wedge it; the likeliest missing ingredient is that the real dispatch joins by spinning on an atomic with no yield (`kernels/pool.rs`) rather than `pthread_join`.

What *is* established is the empirical shape of the problem, below: with the real pool, slicing hangs or costs 1.4–2.6× on OpenBLAS, and is a 1.1–3.0× win on Accelerate. That is what the gating rests on.

## Measurements

**AMD EPYC 7763 (Zen 3, 4 cores), OpenBLAS 0.3.26 pthread** — same microarchitecture family and BLAS variant as the reporter's 5900X. Four CI runs:

| config | A | B | C | D |
|---|---|---|---|---|
| conv, sliced, OpenBLAS threaded | **HANG** | 1532.8 | **HANG** | **HANG** |
| conv, single call | 951.9 | 595.8 | 861.8 | 1011.1 |
| conv, sliced, `OPENBLAS_NUM_THREADS=1` | 946.6 | 612.5 | 924.2 | 993.3 |
| conv, single call, `OPENBLAS_NUM_THREADS=1` | 1450.7 | 775.7 | 1464.5 | 1576.5 |
| linear, sliced | — | 1074.1 | 1523.7 | 1683.0 |
| linear, single call | — | 541.4 | 1057.0 | 1197.1 |
| prefill attention, head-sliced | — | — | 909.3 | 1179.0 |
| prefill attention, single caller | — | — | 586.2 | 657.4 |

Hosted runners are shared and noisy — the same config moves up to 1.7× between runs — so only within-run comparisons count. Within-run:

- **conv sliced + OpenBLAS threaded hangs in 3 of 4 runs**, and cost 2.57× in the run that completed.
- **linear sliced is consistently worse**: 1.98×, 1.44×, 1.41×.
- **prefill attention sliced is consistently worse**: 1.55×, 1.79×.
- **Slicing in isolation is throughput-neutral.** `sliced + OPENBLAS_NUM_THREADS=1` tracks `single call + OpenBLAS threaded` in every run. One unit of parallelism is available and either layer can supply it — so the defect is the *combination*, not the slicing.

The hang being intermittent is what a race in a non-reentrant thread server looks like. It also means CI can exhibit this but cannot gate on it.

**Apple, where all three invert.** M5 Pro (12 threads), and the noisier 3-core `macos-latest` VM:

| path | sliced | single | |
|---|---|---|---|
| conv stem (M5 Pro) | 61 ms | 100 ms | 1.6× better sliced |
| linear (M5 Pro) | 111 ms | 122 ms | 1.1× better sliced |
| prefill attention (M5 Pro) | 33–54 ms | 147 ms | ~3.0× better sliced |
| prefill attention (CI VM) | 104.4 ms | 225.2 ms | 2.2× better sliced |

Clean vendor split on all three, so this gates rather than removes.

## The change

- `conv_pooled_gemm`, `linear_pooled_gemm`, `attn_parallel_heads` — all default to Apple-only, each overridable (`QASR_CONV_POOLED`, `QASR_LINEAR_POOLED`, `QASR_ATTN_POOLED`) so one binary can A/B on hardware we don't have.
- `attn_parallel_heads` is consulted **only for `seq_q > 1`**. Single-token decode takes the BLAS-free online-softmax branch, where head parallelism is safe everywhere and load-bearing for decode throughput — untouched on all platforms. Builds without the `blas` feature return `true` unconditionally.
- Stop printing `vDSP/Accelerate` on non-Apple builds, where `vdsp` reaches no code and `blas` means OpenBLAS. That is what sent the first round of this investigation chasing the wrong library.
- `gemm_pooling_bench` + a CI job exercising all three sites on both vendors, model-free.

macOS unchanged end to end: `conv2d_op` 59.4 ms, `sgemm` 232.8 ms, `attention_causal` 26.7 ms. 86 tests pass.

## Still unexplained — and it is the bigger number

This does **not** account for the 211× on `conv2d_op`, and the gap is sharper than before.

The reporter's `OPENBLAS_NUM_THREADS=1` run left `conv2d_op` at 11864 ms over 87 calls = **136 ms/call**. The same 87 calls in the equivalent CI config take **~11 ms/call** on a *4-core* EPYC. His 12-core 5900X is an order of magnitude worse than a smaller VM of the same microarchitecture, in a configuration that is healthy in CI. Nothing here explains that.

One lead: his `ldd` showed `/usr/lib/libopenblas.so.0`, not the Debian/Ubuntu layout (`/lib/x86_64-linux-gnu/…`), so his build options may differ from the one CI exercises. **If his OpenBLAS is an OpenMP build, `OPENBLAS_NUM_THREADS` is ignored and `OMP_NUM_THREADS` controls it** — in which case his decisive test never disabled OpenBLAS threading at all, which would explain why it moved 6% for him while the same switch is worth ~1.6× in CI.

## For @popsUlfr

Sorry for the two wrong hypotheses along the way — your `OPENBLAS_NUM_THREADS=1` run killed the first one and CI killed the second.

```sh
git fetch origin && git checkout fix/x86-pooled-conv-gemm
RUSTFLAGS="-C target-cpu=native" cargo build --release

# the fix
./target/release/qwen-asr -d qwen3-asr-0.6b -i bench/samples/audio.wav --profile

# old behaviour, same binary — may hang; Ctrl-C is fine
QASR_CONV_POOLED=1 QASR_LINEAR_POOLED=1 QASR_ATTN_POOLED=1 \
  ./target/release/qwen-asr -d qwen3-asr-0.6b -i bench/samples/audio.wav --profile
```

And two things that would help regardless of this branch:

```sh
# which OpenBLAS build? pthread vs openmp changes which knob does anything
nm -D /usr/lib/libopenblas.so.0 | grep -c omp_

# if it is an OpenMP build, OPENBLAS_NUM_THREADS was a no-op and this is the real test
OMP_NUM_THREADS=1 ./target/release/qwen-asr -d qwen3-asr-0.6b -i bench/samples/audio.wav --profile
```

(Ignore the `-v` from my earlier comment — not a valid flag, verbosity is 1 by default.)

## Out of scope, tracked separately

- **`--no-default-features` is unusable on x86** — 201 s, `sgemm` 149434 ms and `bf16_matvec` 107226 ms vs 1940 / 1399 ms with BLAS. Same AVX2 code, same call counts, ~77× slower. Also affects the no-BLAS Android path.
- **Streaming repeats encoder work** — same clip, `--stdin --stream` vs `--stdin`: conv2d 165 vs 87 calls, sgemm 4009 vs 335, attention_causal 392 vs 28. Overlapping windows re-encoded, decode prefixes re-run. Architectural and platform-independent; present on Apple too, just hidden by absolute speed. **This is the actual blocker for live transcription and this PR does not touch it.**
- **No runtime CPU feature detection** — `avx::*` dispatches on `#[cfg(target_arch = "x86_64")]` alone with no `is_x86_feature_detected!`, so any x86 CPU without AVX2 would SIGILL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MP658TDniNedGpMu1XFVAq

