### PR TITLE
Fix ForcedAligner model download repository and checkpoint files

### DIFF
--- a/crates/qwen-asr-cli/src/download.rs
+++ b/crates/qwen-asr-cli/src/download.rs
@@ -36,15 +36,9 @@ pub const KNOWN_MODELS: &[ModelInfo] = &[
     },
     ModelInfo {
         name: "qwen3-aligner-0.6b",
-        repo: "Qwen/Qwen3-ASR-ForcedAligner-0.6B",
-        files: &[
-            "model.safetensors.index.json",
-            "model-00001-of-00002.safetensors",
-            "model-00002-of-00002.safetensors",
-            "vocab.json",
-            "merges.txt",
-        ],
-        description: "Qwen3-ASR ForcedAligner 0.6B — word-level timestamps, ~1.6 GB",
+        repo: "Qwen/Qwen3-ForcedAligner-0.6B",
+        files: &["model.safetensors", "vocab.json", "merges.txt"],
+        description: "Qwen3 ForcedAligner 0.6B — word-level timestamps, ~1.7 GB",
     },
 ];
 
@@ -315,4 +309,20 @@ pub fn handle_download_command(args: &[String]) -> bool {
     }
 
     true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::find_model;
+
+    #[test]
+    fn forced_aligner_download_uses_the_official_single_file_checkpoint() {
+        let model = find_model("qwen3-aligner-0.6b").expect("aligner model is registered");
+
+        assert_eq!(model.repo, "Qwen/Qwen3-ForcedAligner-0.6B");
+        assert_eq!(
+            model.files,
+            &["model.safetensors", "vocab.json", "merges.txt"]
+        );
+    }
 }

--- a/crates/qwen-asr/README.md
+++ b/crates/qwen-asr/README.md
@@ -50,7 +50,7 @@ pip install huggingface_hub
 huggingface_hub download Qwen/Qwen3-ASR-0.6B --local-dir qwen3-asr-0.6b
 
 # Download the 0.6B forced-aligner model (~1.3 GB)
-huggingface_hub download Qwen/Qwen3-ASR-0.6B-Aligner --local-dir qwen3-aligner-0.6b
+huggingface_hub download Qwen/Qwen3-ForcedAligner-0.6B --local-dir qwen3-aligner-0.6b
 ```
 
 ## Usage
@@ -129,7 +129,7 @@ stream_push_audio(&mut ctx, &all_samples, &mut state, true);
 ### Forced Alignment
 
 Produce word-level timestamps for a known transcript. Requires the
-ForcedAligner model variant (`Qwen3-ASR-0.6B-Aligner`).
+ForcedAligner model variant (`Qwen/Qwen3-ForcedAligner-0.6B`).
 
 ```rust,no_run
 use qwen_asr::context::QwenCtx;


### PR DESCRIPTION
## Summary

Fix the built-in ForcedAligner download configuration to use the official Qwen3 ForcedAligner model repository:

https://huggingface.co/Qwen/Qwen3-ForcedAligner-0.6B

The previous configuration referenced a non-existent repository and incorrect sharded checkpoint files.

## Changes

- Change the repository to `Qwen/Qwen3-ForcedAligner-0.6B`
- Download the correct files:
  - `model.safetensors`
  - `vocab.json`
  - `merges.txt`
- Update the ForcedAligner documentation
- Add a regression test for the model mapping

## Verification

- `cargo test -p qwen-asr-cli`
  - 7 tests passed
- Verified the CLI resolves `qwen3-aligner-0.6b` to the official repository
- Successfully loaded `Qwen3-ForcedAligner-0.6B`
- Successfully completed a Cantonese word-level alignment smoke test

## Scope

This PR only fixes model download metadata and documentation. It does not change ASR inference or forced-alignment behavior.