### PR TITLE
fix(cli): Linux build broken — Ordering import gated to macOS

### DIFF
--- a/crates/qwen-asr-cli/src/main.rs
+++ b/crates/qwen-asr-cli/src/main.rs
@@ -8,9 +8,9 @@ use qwen_asr::{align, audio, config, context, kernels, subtitle, transcribe};
 
 use std::io::Write;
 // Only the macOS live-capture loop uses these.
-use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::{AtomicUsize, Ordering};
 #[cfg(target_os = "macos")]
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::AtomicBool;
 #[cfg(target_os = "macos")]
 use std::sync::Arc;
 


### PR DESCRIPTION
a932504 (multi-file parallel transcription) uses `Ordering::Relaxed` at `main.rs:677` in code compiled on every platform, but the `use std::sync::atomic::{AtomicBool, Ordering}` import is behind `#[cfg(target_os = "macos")]` from the earlier live-capture gating — so `cargo build -p qwen-asr-cli` fails on Linux with E0433.

This moves `Ordering` next to `AtomicUsize` (both used cross-platform) and leaves only `AtomicBool` macOS-gated with the live-capture loop.

Verified on x86_64-unknown-linux-gnu: build fails at HEAD, succeeds with this patch; `--release` binary transcribes correctly.

(Found while testing the x86 fixes from #52 — they resolve the short-audio spin from #47 on an i7-1365U, nice work. Happy to share numbers if useful.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MojLSu4Bbw2Bt6VxuYii8N